### PR TITLE
Supress shell's output regarding background processes by separating files

### DIFF
--- a/wpbcopy.sh
+++ b/wpbcopy.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Portable and reliable way to get the directory of this script.
+# Based on http://stackoverflow.com/a/246128
+# then added zsh support from http://stackoverflow.com/a/23259585 .
+WPB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")"; pwd)"
+
+source "$WPB_DIR"/wpb.sh
+
+cat - | (
+    is_env_ok || exit -1
+    
+    TRANS_URL=$(curl -so- --upload-file <(cat | openssl aes-256-cbc -e -pass pass:$WPB_PASSWORD) $TRANSFER_SH/$WPB_ID );
+    curl -s -X POST "$CLIP_NET/$ID_PREFIX/$WPB_ID" --data "content=$TRANS_URL" > /dev/null
+    unspin
+    echo "Copied!" >&2
+) &
+
+trap "kill 0; exit" SIGHUP SIGINT SIGQUIT SIGTERM
+spin $! "Copying..."
+

--- a/wpbpaste.sh
+++ b/wpbpaste.sh
@@ -13,8 +13,8 @@ source "$WPB_DIR"/wpb.sh
     TRANS_URL=$(curl -s "$CLIP_NET/$ID_PREFIX/$WPB_ID" | xmllint --html --xpath '/html/body/div/div/textarea/text()' - 2> /dev/null) || `echo ""`
     if [ "$TRANS_URL" = "" ]; then
         [ -f "$LASTPASTE_PATH" ] || exit 1
-        echo "(Pasting the last paste)" >&2
         unspin
+        echo "(Pasting the last paste)" >&2
         cat "$LASTPASTE_PATH" | openssl aes-256-cbc -d -pass pass:$WPB_PASSWORD
         exit 0
     fi

--- a/wpbpaste.sh
+++ b/wpbpaste.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Portable and reliable way to get the directory of this script.
+# Based on http://stackoverflow.com/a/246128
+# then added zsh support from http://stackoverflow.com/a/23259585 .
+WPB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")"; pwd)"
+
+source "$WPB_DIR"/wpb.sh
+
+(
+    is_env_ok || exit -1
+
+    TRANS_URL=$(curl -s "$CLIP_NET/$ID_PREFIX/$WPB_ID" | xmllint --html --xpath '/html/body/div/div/textarea/text()' - 2> /dev/null) || `echo ""`
+    if [ "$TRANS_URL" = "" ]; then
+        [ -f "$LASTPASTE_PATH" ] || exit 1
+        echo "(Pasting the last paste)" >&2
+        unspin
+        cat "$LASTPASTE_PATH" | openssl aes-256-cbc -d -pass pass:$WPB_PASSWORD
+        exit 0
+    fi
+    curl -so- "$TRANS_URL" > "$LASTPASTE_PATH"
+    unspin
+    cat "$LASTPASTE_PATH" | openssl aes-256-cbc -d -pass pass:$WPB_PASSWORD
+) &
+
+trap "kill 0; exit" SIGHUP SIGINT SIGQUIT SIGTERM
+spin $! "Pasting..."


### PR DESCRIPTION
(will fix #2 .)

`wpb.sh` provides wrapper function to execute `wpbcopy.sh` and `wpbpaste.sh`.
Also, `wpb.sh` provides common codes used by them the bodies, so it is `source`d from them.

PR also includes cosmetic changes related to `unspin`'s place.

適当にやってみたんだけど、こういう分割の方法で良いのかわかんないのでおすすめのパターンとかあったら教えてくださいｗ
