### PR TITLE
Error handling during connecting the services

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -13,6 +13,9 @@ fi
 TEST_DIR="$(dirname $0)"
 . "${TEST_DIR}/../wpb.sh"
 
+CLIP_NET_NG="https://example.com"
+TRANSFER_SH_NG="https://example.com"
+
 WPB_ID=""
 WPB_PASSWORD=""
 
@@ -21,6 +24,27 @@ setUp () {
     WPB_ID="$(cat /dev/urandom | strings | grep -o '[[:alnum:]]' | tr -d '\n' | fold -w 128 | head -n 1)"
     WPB_PASSWORD="$(cat /dev/urandom | strings | grep -o '[[:alnum:]]' | tr -d '\n' | fold -w 128 | head -n 1)"
 }
+
+test_copy_transfer_sh_dead () {
+    echo "aaaa" | tr -d '\n' | TRANSFER_SH="$TRANSFER_SH_NG" wpbcopy
+    assertEquals 128 $?
+}
+
+test_copy_clip_net_dead () {
+    echo "aaaa" | tr -d '\n' | CLIP_NET="$CLIP_NET_NG" wpbcopy
+    assertEquals 129 $?
+}
+
+test_paste_clip_net_dead () {
+    CLIP_NET="$CLIP_NET_NG" wpbpaste
+    assertEquals 129 $?
+}
+
+# FIXME: There's no way to change `TRANS_URL` got from cl1p, so we cannot
+#        the the case the transfer.sh was gone during pasting
+# test_paste_transfer_sh_dead () {
+#     ...
+# }
 
 test_simple_string () {
     echo "aaaa" | tr -d '\n' | wpbcopy

--- a/wpb.sh
+++ b/wpb.sh
@@ -14,6 +14,28 @@ ID_PREFIX="wpbcopy"
 CLIP_NET="https://cl1p.net"
 TRANSFER_SH="https://transfer.sh"
 
+makePipe () {
+    PIPEDIR="$(mktemp -d)" || exit -2;
+    PIPE="${PIPEDIR}/pipe"
+    mkfifo "$PIPE" || exit -2;
+}
+
+cleanPipe () {
+    rm -r "$PIPEDIR"
+}
+
+exit_ () {
+    local code=$1
+    echo $code > "$PIPE" &
+    exit
+}
+
+waitExitcode () {
+    local code=$(cat "$PIPE")
+    cleanPipe
+    return $code
+}
+
 unspin () {
     tput cnorm >&2 # make the cursor visible
     echo -n $'\r'"`tput el`" >&2

--- a/wpb.sh
+++ b/wpb.sh
@@ -11,8 +11,8 @@ LASTPASTE_PATH="${TMPDIR}/lastPaste"
 ID_PREFIX="wpbcopy"
 
 # Dependent services
-CLIP_NET="https://cl1p.net"
-TRANSFER_SH="https://transfer.sh"
+CLIP_NET="${CLIP_NET:-https://cl1p.net}"
+TRANSFER_SH="${TRANSFER_SH:-https://transfer.sh}"
 
 makePipe () {
     PIPEDIR="$(mktemp -d)" || exit -2;

--- a/wpbcopy.sh
+++ b/wpbcopy.sh
@@ -6,16 +6,33 @@
 WPB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")"; pwd)"
 
 source "$WPB_DIR"/wpb.sh
+is_env_ok || exit -1
+
+makePipe
 
 cat - | (
-    is_env_ok || exit -1
-    
-    TRANS_URL=$(curl -so- --upload-file <(cat | openssl aes-256-cbc -e -pass pass:$WPB_PASSWORD) $TRANSFER_SH/$WPB_ID );
-    curl -s -X POST "$CLIP_NET/$ID_PREFIX/$WPB_ID" --data "content=$TRANS_URL" > /dev/null
+    TRANS_URL=$(curl -so- --fail --upload-file <(cat | openssl aes-256-cbc -e -pass pass:$WPB_PASSWORD) $TRANSFER_SH/$WPB_ID );
+
+    if [ $? -ne 0 ]; then
+        unspin
+        echo "Failed to upload the content" >&2
+        exit_ 128
+    fi
+
+    curl -s -X POST "$CLIP_NET/$ID_PREFIX/$WPB_ID" --fail --data "content=$TRANS_URL" > /dev/null
+
+    if [ $? -ne 0 ]; then
+        unspin
+        echo "Failed to save the content url" >&2
+        exit_ 129
+    fi
+
     unspin
     echo "Copied!" >&2
+    exit_ 0
 ) &
 
-trap "kill 0; exit" SIGHUP SIGINT SIGQUIT SIGTERM
+trap "kill 0; exit -2" SIGHUP SIGINT SIGQUIT SIGTERM
 spin $! "Copying..."
 
+exit $(waitExitcode)

--- a/wpbcopy.sh
+++ b/wpbcopy.sh
@@ -32,7 +32,7 @@ cat - | (
     exit_ 0
 ) &
 
-trap "kill 0; exit -2" SIGHUP SIGINT SIGQUIT SIGTERM
+trap "kill 0; exit 2" SIGHUP SIGINT SIGQUIT SIGTERM
 spin $! "Copying..."
 
 exit $(waitExitcode)

--- a/wpbpaste.sh
+++ b/wpbpaste.sh
@@ -7,21 +7,45 @@ WPB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")"; pwd)"
 
 source "$WPB_DIR"/wpb.sh
 
-(
-    is_env_ok || exit -1
+is_env_ok || exit -1
 
-    TRANS_URL=$(curl -s "$CLIP_NET/$ID_PREFIX/$WPB_ID" | xmllint --html --xpath '/html/body/div/div/textarea/text()' - 2> /dev/null) || `echo ""`
+makePipe
+
+(
+    CLIP_BODY=$(curl --fail -so- "$CLIP_NET/$ID_PREFIX/$WPB_ID" 2> /dev/null)
+    if [ $? -ne 0 ]; then
+        unspin
+        echo "Failed to get the content url" >&2
+        exit_ 129
+    fi
+
+    TRANS_URL=$(echo "$CLIP_BODY" |
+                       xmllint --html --xpath '/html/body/div/div/textarea/text()' - 2> /dev/null)
+
     if [ "$TRANS_URL" = "" ]; then
-        [ -f "$LASTPASTE_PATH" ] || exit 1
+        [ -f "$LASTPASTE_PATH" ] ||
+            { unspin;
+              echo "Nothing has been copied yet.";
+              exit_ 1; }
+
         unspin
         echo "(Pasting the last paste)" >&2
         cat "$LASTPASTE_PATH" | openssl aes-256-cbc -d -pass pass:$WPB_PASSWORD
-        exit 0
+        exit_ 0
     fi
-    curl -so- "$TRANS_URL" > "$LASTPASTE_PATH"
+    curl --fail -so- "$TRANS_URL" > "$LASTPASTE_PATH" 2> /dev/null
+    if [ $? -ne 0 ]; then
+        unspin
+        echo "Failed to get the content" >&2
+        exit_ 128
+    fi
+
     unspin
     cat "$LASTPASTE_PATH" | openssl aes-256-cbc -d -pass pass:$WPB_PASSWORD
+    exit_ 0
 ) &
 
 trap "kill 0; exit" SIGHUP SIGINT SIGQUIT SIGTERM
 spin $! "Pasting..."
+
+exit $(waitExitcode)

--- a/wpbpaste.sh
+++ b/wpbpaste.sh
@@ -45,7 +45,7 @@ makePipe
     exit_ 0
 ) &
 
-trap "kill 0; exit" SIGHUP SIGINT SIGQUIT SIGTERM
+trap "kill 0; exit 2" SIGHUP SIGINT SIGQUIT SIGTERM
 spin $! "Pasting..."
 
 exit $(waitExitcode)


### PR DESCRIPTION
This will fix #7, showing the error if the connection to the dependent services, i.e., `cl1p.net` and `transfer.sh`, was failed.

And returns following exit status.
 - `128`: failed to connect `transfer.sh`
 - `129`: failed to connect `cl1p.net`

Also this PR add exit code, for the other errors:
 - `2`: terminated by user.
 - `-2` (`254`): named pipe creation failed.

エラーコード適当なので後で整理しましょう...