### PR TITLE
Improve showing spinner architecture and remove named pipe

### DIFF
--- a/wpbcopy.sh
+++ b/wpbcopy.sh
@@ -8,31 +8,25 @@ WPB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")"; pwd)"
 source "$WPB_DIR"/wpb.sh
 is_env_ok || exit -1
 
-makePipe
-
-cat - | (
-    TRANS_URL=$(curl -so- --fail --upload-file <(cat | openssl aes-256-cbc -e -pass pass:$WPB_PASSWORD) $TRANSFER_SH/$WPB_ID );
-
-    if [ $? -ne 0 ]; then
-        unspin
-        echo "Failed to upload the content" >&2
-        exit_ 128
-    fi
-
-    curl -s -X POST "$CLIP_NET/$ID_PREFIX/$WPB_ID" --fail --data "content=$TRANS_URL" > /dev/null
-
-    if [ $? -ne 0 ]; then
-        unspin
-        echo "Failed to save the content url" >&2
-        exit_ 129
-    fi
-
-    unspin
-    echo "Copied!" >&2
-    exit_ 0
-) &
-
 trap "kill 0; exit 2" SIGHUP SIGINT SIGQUIT SIGTERM
-spin $! "Copying..."
+spin "Copying..."
 
-exit $(waitExitcode)
+TRANS_URL=$(curl -so- --fail --upload-file <(cat | openssl aes-256-cbc -e -pass pass:$WPB_PASSWORD) $TRANSFER_SH/$WPB_ID );
+
+if [ $? -ne 0 ]; then
+    unspin
+    echo "Failed to upload the content" >&2
+    exit 128
+fi
+
+curl -s -X POST "$CLIP_NET/$ID_PREFIX/$WPB_ID" --fail --data "content=$TRANS_URL" > /dev/null
+
+if [ $? -ne 0 ]; then
+    unspin
+    echo "Failed to save the content url" >&2
+    exit 129
+fi
+
+unspin
+echo "Copied!" >&2
+exit 0

--- a/wpbpaste.sh
+++ b/wpbpaste.sh
@@ -9,44 +9,39 @@ source "$WPB_DIR"/wpb.sh
 
 is_env_ok || exit -1
 
-makePipe
+trap "kill 0; exit 2" SIGHUP SIGINT SIGQUIT SIGTERM
+spin "Pasting..."
 
-(
-    CLIP_BODY=$(curl --fail -so- "$CLIP_NET/$ID_PREFIX/$WPB_ID" 2> /dev/null)
-    if [ $? -ne 0 ]; then
-        unspin
-        echo "Failed to get the content url" >&2
-        exit_ 129
-    fi
+CLIP_BODY=$(curl --fail -so- "$CLIP_NET/$ID_PREFIX/$WPB_ID" 2> /dev/null)
+if [ $? -ne 0 ]; then
+    unspin
+    echo "Failed to get the content url" >&2
+    exit 129
+fi
 
-    TRANS_URL=$(echo "$CLIP_BODY" |
-                        # Use only (extended) regular expression compatible with POSIX.
-                       sed 's/<[^>]*>//g' | grep -E "${TRANSFER_SH}/[^/]+/.+" | head -n 1 2> /dev/null)
+TRANS_URL=$(echo "$CLIP_BODY" |
+                   # Use only (extended) regular expression compatible with POSIX.
+                   sed 's/<[^>]*>//g' | grep -E "${TRANSFER_SH}/[^/]+/.+" | head -n 1 2> /dev/null)
 
-    if [ "$TRANS_URL" = "" ]; then
-        [ -f "$LASTPASTE_PATH" ] ||
-            { unspin;
-              echo "Nothing has been copied yet.";
-              exit_ 1; }
-
-        unspin
-        echo "(Pasting the last paste)" >&2
-        cat "$LASTPASTE_PATH" | openssl aes-256-cbc -d -pass pass:$WPB_PASSWORD
-        exit_ 0
-    fi
-    curl --fail -so- "$TRANS_URL" > "$LASTPASTE_PATH" 2> /dev/null
-    if [ $? -ne 0 ]; then
-        unspin
-        echo "Failed to get the content" >&2
-        exit_ 128
-    fi
+if [ "$TRANS_URL" = "" ]; then
+    [ -f "$LASTPASTE_PATH" ] ||
+        { unspin;
+          echo "Nothing has been copied yet.";
+          exit 1; }
 
     unspin
+    echo "(Pasting the last paste)" >&2
     cat "$LASTPASTE_PATH" | openssl aes-256-cbc -d -pass pass:$WPB_PASSWORD
-    exit_ 0
-) &
+    exit 0
+fi
+curl --fail -so- "$TRANS_URL" > "$LASTPASTE_PATH" 2> /dev/null
+if [ $? -ne 0 ]; then
+    unspin
+    echo "Failed to get the content" >&2
+    exit 128
+fi
 
-trap "kill 0; exit 2" SIGHUP SIGINT SIGQUIT SIGTERM
-spin $! "Pasting..."
+unspin
+cat "$LASTPASTE_PATH" | openssl aes-256-cbc -d -pass pass:$WPB_PASSWORD
+exit 0
 
-exit $(waitExitcode)

--- a/wpbpaste.sh
+++ b/wpbpaste.sh
@@ -26,7 +26,7 @@ TRANS_URL=$(echo "$CLIP_BODY" |
 if [ "$TRANS_URL" = "" ]; then
     [ -f "$LASTPASTE_PATH" ] ||
         { unspin;
-          echo "Nothing has been copied yet.";
+          echo "Nothing has been copied yet." >&2;
           exit 1; }
 
     unspin


### PR DESCRIPTION
👷🌑 / 🌀🌝　⏩　👷🌝 / 🌀🌚
====================== 

Now the main process👷 works in the foreground🌝  and the spinner🌀 is in the background🌚. It is more intuitive.

So the way to send the exit codes got more simple. And no more named pipe. 💨

This also fix #3 .