### PR TITLE
Change functions and variables name to give the namespace (fix #12)

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -14,8 +14,8 @@ fi
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")"; pwd)"
 . "${TEST_DIR}/../wpb.sh"
 
-CLIP_NET_NG="https://example.com"
-TRANSFER_SH_NG="https://example.com"
+WPB_CLIP_NET_NG="https://example.com"
+WPB_TRANSFER_SH_NG="https://example.com"
 
 WPB_ID=""
 WPB_PASSWORD=""
@@ -36,17 +36,17 @@ cl1pMockserver () {
 }
 
 test_copy_transfer_sh_dead () {
-    echo "aaaa" | tr -d '\n' | TRANSFER_SH="$TRANSFER_SH_NG" wpbcopy
+    echo "aaaa" | tr -d '\n' | WPB_TRANSFER_SH="$WPB_TRANSFER_SH_NG" wpbcopy
     assertEquals 128 $?
 }
 
 test_copy_clip_net_dead () {
-    echo "aaaa" | tr -d '\n' | CLIP_NET="$CLIP_NET_NG" wpbcopy
+    echo "aaaa" | tr -d '\n' | WPB_CLIP_NET="$WPB_CLIP_NET_NG" wpbcopy
     assertEquals 129 $?
 }
 
 test_paste_clip_net_dead () {
-    CLIP_NET="$CLIP_NET_NG" wpbpaste
+    WPB_CLIP_NET="$WPB_CLIP_NET_NG" wpbpaste
     assertEquals 129 $?
 }
 
@@ -55,13 +55,13 @@ test_paste_transfer_sh_dead () {
     local port=10000
     # Run mock server to simulate c1ip.net with 10000 port.
     cl1pMockserver $port > /dev/null 2>&1 &
-    CLIP_NET="http://localhost:$port" TRANSFER_SH="http://example.com" wpbpaste
+    WPB_CLIP_NET="http://localhost:$port" WPB_TRANSFER_SH="http://example.com" wpbpaste
     assertEquals 128 $?
 }
 
 test_lack_dependency () {
     # It fails, if there is `hogehogeoppaipai` command.
-    echo aaa | DEPENDENCIES="hogehogeoppaipai curl" wpbcopy
+    echo aaa | _WPB_DEPENDENCIES="hogehogeoppaipai curl" wpbcopy
     assertEquals 255 $?
 }
 

--- a/wpb.sh
+++ b/wpb.sh
@@ -3,27 +3,27 @@
 # Portable and reliable way to get the directory of this script.
 # Based on http://stackoverflow.com/a/246128
 # then added zsh support from http://stackoverflow.com/a/23259585 .
-WPB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")"; pwd)"
+_WPB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")"; pwd)"
+
+# Dependent commands (non POSIX commands)
+_WPB_DEPENDENCIES="${_WPB_DEPENDENCIES:-yes openssl curl perl}"
 
 # Whare the last pasted content stored is.
 # It is re-used when you failed to get the remote content.
-LASTPASTE_PATH="${TMPDIR}/lastPaste"
-ID_PREFIX="wpbcopy"
+WPB_LASTPASTE_PATH="${TMPDIR}/lastPaste"
+WPB_ID_PREFIX="wpbcopy"
 
 # Dependent services
-CLIP_NET="${CLIP_NET:-https://cl1p.net}"
-TRANSFER_SH="${TRANSFER_SH:-https://transfer.sh}"
+WPB_CLIP_NET="${WPB_CLIP_NET:-https://cl1p.net}"
+WPB_TRANSFER_SH="${WPB_TRANSFER_SH:-https://transfer.sh}"
 
-# Dependent commands (non POSIX commands)
-DEPENDENCIES="${DEPENDENCIES:-yes openssl curl perl}"
-
-unspin () {
-    kill $SPIN_PID
+__wpb::unspin () {
+    kill $_WPB_SPIN_PID
     tput cnorm >&2 # make the cursor visible
     echo -n $'\r'"`tput el`" >&2
 }
 
-spin () {
+__wpb::spin () {
     local message=$1
     tput civis >&2 # make the cursor invisible
 
@@ -40,10 +40,10 @@ spin () {
         done < <(yes "⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏" | tr ' ' '\n')
     )&
 
-    SPIN_PID=$!
+    _WPB_SPIN_PID=$!
 }
 
-is_env_ok () {
+__wpb::is_env_ok () {
     while read cmd ; do
         type $cmd > /dev/null 2>&1
         if [ $? -ne 0 ]; then
@@ -52,7 +52,7 @@ is_env_ok () {
             # After `--`, any arguments are not interpreted as option.
             return -- -1
         fi
-    done < <(echo "$DEPENDENCIES" | tr ' ' '\n')
+    done < <(echo "$_WPB_DEPENDENCIES" | tr ' ' '\n')
 
     [ -z "$WPB_ID" ] && echo "Set environment variable (WPB_ID)." >&2 && return -- -1
     [ -z "$WPB_PASSWORD" ] && echo "Set environment variable (WPB_PASSWORD)." >&2 && return -- -1
@@ -60,9 +60,9 @@ is_env_ok () {
 }
 
 wpbcopy () {
-    WPB_ID="$WPB_ID" WPB_PASSWORD="$WPB_PASSWORD" "$WPB_DIR"/wpbcopy.sh
+    WPB_ID="$WPB_ID" WPB_PASSWORD="$WPB_PASSWORD" "$_WPB_DIR"/wpbcopy.sh
 }
 
 wpbpaste () {
-    WPB_ID="$WPB_ID" WPB_PASSWORD="$WPB_PASSWORD" "$WPB_DIR"/wpbpaste.sh
+    WPB_ID="$WPB_ID" WPB_PASSWORD="$WPB_PASSWORD" "$_WPB_DIR"/wpbpaste.sh
 }

--- a/wpbcopy.sh
+++ b/wpbcopy.sh
@@ -3,30 +3,30 @@
 # Portable and reliable way to get the directory of this script.
 # Based on http://stackoverflow.com/a/246128
 # then added zsh support from http://stackoverflow.com/a/23259585 .
-WPB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")"; pwd)"
+_WPB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")"; pwd)"
 
-source "$WPB_DIR"/wpb.sh
-is_env_ok || exit -1
+source "$_WPB_DIR"/wpb.sh
+__wpb::is_env_ok || exit -1
 
 trap "kill 0; exit 2" SIGHUP SIGINT SIGQUIT SIGTERM
-spin "Copying..."
+__wpb::spin "Copying..."
 
-TRANS_URL=$(curl -so- --fail --upload-file <(cat | openssl aes-256-cbc -e -pass pass:$WPB_PASSWORD) $TRANSFER_SH/$WPB_ID );
+TRANS_URL=$(curl -so- --fail --upload-file <(cat | openssl aes-256-cbc -e -pass pass:$WPB_PASSWORD) $WPB_TRANSFER_SH/$WPB_ID );
 
 if [ $? -ne 0 ]; then
-    unspin
+    __wpb::unspin
     echo "Failed to upload the content" >&2
     exit 128
 fi
 
-curl -s -X POST "$CLIP_NET/$ID_PREFIX/$WPB_ID" --fail --data "content=$TRANS_URL" > /dev/null
+curl -s -X POST "$WPB_CLIP_NET/$WPB_ID_PREFIX/$WPB_ID" --fail --data "content=$TRANS_URL" > /dev/null
 
 if [ $? -ne 0 ]; then
-    unspin
+    __wpb::unspin
     echo "Failed to save the content url" >&2
     exit 129
 fi
 
-unspin
+__wpb::unspin
 echo "Copied!" >&2
 exit 0

--- a/wpbpaste.sh
+++ b/wpbpaste.sh
@@ -3,45 +3,45 @@
 # Portable and reliable way to get the directory of this script.
 # Based on http://stackoverflow.com/a/246128
 # then added zsh support from http://stackoverflow.com/a/23259585 .
-WPB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")"; pwd)"
+_WPB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")"; pwd)"
 
-source "$WPB_DIR"/wpb.sh
+source "$_WPB_DIR"/wpb.sh
 
-is_env_ok || exit -1
+__wpb::is_env_ok || exit -1
 
 trap "kill 0; exit 2" SIGHUP SIGINT SIGQUIT SIGTERM
-spin "Pasting..."
+__wpb::spin "Pasting..."
 
-CLIP_BODY=$(curl --fail -so- "$CLIP_NET/$ID_PREFIX/$WPB_ID" 2> /dev/null)
+CLIP_BODY=$(curl --fail -so- "$WPB_CLIP_NET/$WPB_ID_PREFIX/$WPB_ID" 2> /dev/null)
 if [ $? -ne 0 ]; then
-    unspin
+    __wpb::unspin
     echo "Failed to get the content url" >&2
     exit 129
 fi
 
 TRANS_URL=$(echo "$CLIP_BODY" |
                    # Use only (extended) regular expression compatible with POSIX.
-                   sed 's/<[^>]*>//g' | grep -E "${TRANSFER_SH}/[^/]+/.+" | head -n 1 2> /dev/null)
+                   sed 's/<[^>]*>//g' | grep -E "${WPB_TRANSFER_SH}/[^/]+/.+" | head -n 1 2> /dev/null)
 
 if [ "$TRANS_URL" = "" ]; then
-    [ -f "$LASTPASTE_PATH" ] ||
-        { unspin;
+    [ -f "$WPB_LASTPASTE_PATH" ] ||
+        { __wpb::unspin;
           echo "Nothing has been copied yet." >&2;
           exit 1; }
 
-    unspin
+    __wpb::unspin
     echo "(Pasting the last paste)" >&2
-    cat "$LASTPASTE_PATH" | openssl aes-256-cbc -d -pass pass:$WPB_PASSWORD
+    cat "$WPB_LASTPASTE_PATH" | openssl aes-256-cbc -d -pass pass:$WPB_PASSWORD
     exit 0
 fi
-curl --fail -so- "$TRANS_URL" > "$LASTPASTE_PATH" 2> /dev/null
+curl --fail -so- "$TRANS_URL" > "$WPB_LASTPASTE_PATH" 2> /dev/null
 if [ $? -ne 0 ]; then
-    unspin
+    __wpb::unspin
     echo "Failed to get the content" >&2
     exit 128
 fi
 
-unspin
-cat "$LASTPASTE_PATH" | openssl aes-256-cbc -d -pass pass:$WPB_PASSWORD
+__wpb::unspin
+cat "$WPB_LASTPASTE_PATH" | openssl aes-256-cbc -d -pass pass:$WPB_PASSWORD
 exit 0
 


### PR DESCRIPTION
Need to be considered:
 - Variables in `wpbcopy.sh` and `wpbpaste.sh` such as `$TRANS_URL` and `$CLIP_BODY` left as is. Because I think they the files are not expected to be `source`d  directly so they will be kept in the scope of the file, I think. Should we rename them, too?