### PR TITLE
Feature/args id pass (For #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ttcopy: Trans-Terminal Copy/Paste
 
+[![latest version](https://img.shields.io/github/release/greymd/ttcopy.svg)](https://github.com/greymd/ttcopy/releases/latest)
 [![Build Status](https://travis-ci.org/greymd/ttcopy.svg?branch=master)](https://travis-ci.org/greymd/ttcopy)
 
 Provide copying and pasting within multiple hosts through the Web.

--- a/test/test.sh
+++ b/test/test.sh
@@ -124,8 +124,6 @@ test_option_combination () {
 test_id_pass_given_by_arg () {
     TTCP_ID=""
     TTCP_PASSWORD=""
-    # FIXME: Test cases does not pass with long id/password like 64 characters.
-    #        Investigate the reason.
     local NEW_ID_1="$(dummyString)"
     local NEW_PASSWORD_1="$(dummyString)"
     local NEW_ID_2="$(dummyString)"
@@ -159,6 +157,20 @@ test_id_pass_given_by_arg () {
     assertEquals "I have a pineapple." "$(ttpaste --id="$NEW_ID_2" --password="$NEW_PASSWORD_2")"
 
     assertNotEquals "$(ttpaste -i "$NEW_ID_1" -p "$NEW_PASSWORD_1")" "$(ttpaste -i "$NEW_ID_2" -p "$NEW_PASSWORD_2")"
+
+    # Password is defined by the variable.
+    TTCP_ID=""
+    TTCP_PASSWORD="$(dummyString)"
+    echo "Apple Pen" | ttcopy -i "$NEW_ID_1"
+    assertEquals 0 $?
+    assertEquals "Apple Pen" "$(ttpaste -i "$NEW_ID_1")"
+
+    # ID is defined by the variable.
+    TTCP_ID="$(dummyString)"
+    TTCP_PASSWORD=""
+    echo "Pineapple Pen" | ttcopy -p "$NEW_PASSWORD_1"
+    assertEquals 0 $?
+    assertEquals "Pineapple Pen" "$(ttpaste -p "$NEW_PASSWORD_1")"
 }
 
 test_id_pass_given_by_arg_error () {

--- a/test/test.sh
+++ b/test/test.sh
@@ -130,7 +130,6 @@ test_id_pass_given_by_arg () {
     local NEW_PASSWORD_2="$(dummyString)"
 
     # Short option
-    echo "echo 'I have a pen.' | ttcopy -i $NEW_ID_1 -p $NEW_PASSWORD_1"
     echo 'I have a pen.' | ttcopy -i $NEW_ID_1 -p $NEW_PASSWORD_1
     assertEquals 0 $?
     assertEquals "I have a pen." "$(ttpaste -i "$NEW_ID_1" -p "$NEW_PASSWORD_1")"

--- a/test/test.sh
+++ b/test/test.sh
@@ -35,6 +35,11 @@ cl1pMockserver () {
     printf "HTTP/1.0 200 Ok\n\nhttp://example.com/URL404/file.txt" | nc -l $port
 }
 
+# Generate dummy data
+dummyString () {
+    cat /dev/urandom | strings | grep -o '[[:alnum:]]' | tr -d '\n' | fold -w 128 | head -n 1
+}
+
 test_copy_transfer_sh_dead () {
     echo "aaaa" | tr -d '\n' | TTCP_TRANSFER_SH="$TTCP_TRANSFER_SH_NG" ttcopy
     assertEquals 128 $?
@@ -98,6 +103,99 @@ test_usage () {
     assertEquals 0 $?
     ttpaste --help | grep -E 'Usage: ttpaste'
     assertEquals 0 $?
+}
+
+# Do not be sensitive.
+# This test case can easily be increased.
+test_option_combination () {
+    # help + other option
+    ttcopy -hp hogehoge | grep -E 'Usage: ttcopy'
+    assertEquals 0 $?
+
+    # Help + other option
+    ttcopy --help -p password -i sample | grep -E 'Usage: ttcopy'
+    assertEquals 0 $?
+
+    # version + password + id + help
+    ttcopy -V --help -p password -i sample | grep -E '[0-9]+\.[0-9]+\.[0-9]+'
+    assertEquals 0 $?
+}
+
+test_id_pass_given_by_arg () {
+    TTCP_ID=""
+    TTCP_PASSWORD=""
+    # FIXME: Test cases does not pass with long id/password like 64 characters.
+    #        Investigate the reason.
+    local NEW_ID_1="$(dummyString)"
+    local NEW_PASSWORD_1="$(dummyString)"
+    local NEW_ID_2="$(dummyString)"
+    local NEW_PASSWORD_2="$(dummyString)"
+
+    # Short option
+    echo "echo 'I have a pen.' | ttcopy -i $NEW_ID_1 -p $NEW_PASSWORD_1"
+    echo 'I have a pen.' | ttcopy -i $NEW_ID_1 -p $NEW_PASSWORD_1
+    assertEquals 0 $?
+    assertEquals "I have a pen." "$(ttpaste -i "$NEW_ID_1" -p "$NEW_PASSWORD_1")"
+    assertEquals "I have a pen." "$(ttpaste -i "$NEW_ID_1" -p "$NEW_PASSWORD_1")"
+
+    # Long option
+    echo "I have an apple." | ttcopy --id="$NEW_ID_2" --password="$NEW_PASSWORD_2"
+    assertEquals 0 $?
+    assertEquals "I have an apple." "$(ttpaste --id="$NEW_ID_2" --password="$NEW_PASSWORD_2")"
+    assertEquals "I have an apple." "$(ttpaste --id="$NEW_ID_2" --password="$NEW_PASSWORD_2")"
+
+    assertNotEquals "$(ttpaste -i "$NEW_ID_1" -p "$NEW_PASSWORD_1")" "$(ttpaste -i "$NEW_ID_2" -p "$NEW_PASSWORD_2")"
+
+    # Short & Long option
+    echo "I have a pen." | ttcopy -i "$NEW_ID_1" --password="$NEW_PASSWORD_1"
+    assertEquals 0 $?
+    assertEquals "I have a pen." "$(ttpaste -i "$NEW_ID_1" --password="$NEW_PASSWORD_1")"
+    assertEquals "I have a pen." "$(ttpaste -i "$NEW_ID_1" --password="$NEW_PASSWORD_1")"
+
+    # Long & Short option
+    echo "I have a pineapple." | ttcopy --id="$NEW_ID_2" --password="$NEW_PASSWORD_2"
+    assertEquals 0 $?
+    assertEquals "I have a pineapple." "$(ttpaste --id="$NEW_ID_2" --password="$NEW_PASSWORD_2")"
+    assertEquals "I have a pineapple." "$(ttpaste --id="$NEW_ID_2" --password="$NEW_PASSWORD_2")"
+
+    assertNotEquals "$(ttpaste -i "$NEW_ID_1" -p "$NEW_PASSWORD_1")" "$(ttpaste -i "$NEW_ID_2" -p "$NEW_PASSWORD_2")"
+}
+
+test_id_pass_given_by_arg_error () {
+    TTCP_ID=""
+    TTCP_PASSWORD=""
+
+    # Short option: password is empty
+    echo AAA | ttcopy -i "dummy"
+    assertEquals 255 $?
+
+    # Long option: password is empty
+    echo AAA | ttcopy --id=dummy
+    assertEquals 255 $?
+
+    # Short option: ID is empty
+    echo AAA | ttcopy -p dummy
+    assertEquals 255 $?
+
+    # Long option: ID is empty
+    echo AAA | ttcopy --password=dummy
+    assertEquals 255 $?
+
+    # Short option: password is empty
+    ttpaste -i dummy
+    assertEquals 255 $?
+
+    # Long option: password is empty
+    ttpaste --id=dummy
+    assertEquals 255 $?
+
+    # Short option: ID is empty
+    ttpaste -p dummy
+    assertEquals 255 $?
+
+    # Long option: ID is empty
+    ttpaste --password=dummy
+    assertEquals 255 $?
 }
 
 test_simple_string () {

--- a/test/test.sh
+++ b/test/test.sh
@@ -119,6 +119,30 @@ test_option_combination () {
     # version + password + id + help
     ttcopy -V --help -p password -i sample | grep -E '[0-9]+\.[0-9]+\.[0-9]+'
     assertEquals 0 $?
+
+    # Undefined option
+    ttcopy -Z
+    assertEquals 4 $?
+
+    # Undefined options + valid options
+    seq 10 | ttcopy -Z --help -p password -i sample
+    assertEquals 4 $?
+
+    # Undefined argument
+    ttcopy foobar
+    assertEquals 4 $?
+
+    # Undefined option
+    ttpaste -Z
+    assertEquals 4 $?
+
+    # Undefined options + valid options
+    seq 10 | ttpaste -Z --help -p password -i sample
+    assertEquals 4 $?
+
+    # Undefined argument
+    ttpaste foobar
+     $?
 }
 
 test_id_pass_given_by_arg () {

--- a/ttcopy.sh
+++ b/ttcopy.sh
@@ -4,12 +4,23 @@
 # Based on http://stackoverflow.com/a/246128
 # then added zsh support from http://stackoverflow.com/a/23259585 .
 _TTCP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")"; pwd)"
-
 source "$_TTCP_DIR"/ttcp.sh
 
 # Option parser is called prior to is_env_ok
 # Because id/password might be given by user.
 __ttcp::opts "$@"
+_opt_status=$?
+
+# There is invalid options/arguments.
+if [ $_opt_status -eq 4 ]; then
+    # Same as GNU sed.
+    exit 4
+
+# Shows usage or version number.
+elif [ $_opt_status -eq 254 ]; then
+    exit 0
+fi
+
 __ttcp::is_env_ok || exit -1
 
 trap "__ttcp::unspin; kill 0; exit 2" SIGHUP SIGINT SIGQUIT SIGTERM

--- a/ttcopy.sh
+++ b/ttcopy.sh
@@ -6,10 +6,13 @@
 _TTCP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")"; pwd)"
 
 source "$_TTCP_DIR"/ttcp.sh
+
+# Option parser is called prior to is_env_ok
+# Because id/password might be given by user.
+__ttcp::opts "$@"
 __ttcp::is_env_ok || exit -1
 
 trap "__ttcp::unspin; kill 0; exit 2" SIGHUP SIGINT SIGQUIT SIGTERM
-__ttcp::opts "$@"
 __ttcp::spin "Copying..."
 
 TRANS_URL=$(curl -so- --fail --upload-file <(cat | openssl aes-256-cbc -e -pass pass:$TTCP_PASSWORD) $TTCP_TRANSFER_SH/$TTCP_ID );

--- a/ttcp.sh
+++ b/ttcp.sh
@@ -38,7 +38,7 @@ __ttcp::usage () {
     echo "  -h, --help                         Output a usage message and exit."
     echo "  -V, --version                      Output the version number of $_cmd and exit."
     echo "  -i ID, --id=ID                     Specify ID to identify the data."
-    echo "  -p PASSWORD, --password=PASSWORD   Specify Password to encrypt/decrypt the data."
+    echo "  -p PASSWORD, --password=PASSWORD   Specify password to encrypt/decrypt the data."
 }
 
 __ttcp::opts () {

--- a/ttcp.sh
+++ b/ttcp.sh
@@ -51,11 +51,11 @@ __ttcp::opts () {
             # Long options
             --help)
                 __ttcp::usage
-                exit 0
+                return 254
                 ;;
             --version)
                 __ttcp::version
-                exit 0
+                return 254
                 ;;
             --id=*)
                 TTCP_ID="${1#--id=}"
@@ -67,34 +67,53 @@ __ttcp::opts () {
                 ;;
 
             # Short options
-            -*)
+            -[hVip])
+                # For --help
                 if [[ "$1" =~ 'h' ]]; then
                     __ttcp::usage
-                    exit 0
+                    return 254
                 fi
+
+                # For --version
                 if [[ "$1" =~ 'V' ]]; then
                     __ttcp::version
-                    exit 0
+                    return 254
                 fi
+
+                # For --id
                 if [[ "$1" =~ 'i' ]]; then
                     TTCP_ID="$2"
                     shift
-                    shift
+
+                # For --password
                 elif [[ "$1" =~ 'p' ]]; then
                     TTCP_PASSWORD="$2"
                     shift
-                    shift
                 fi
+
+                # Rotate arguments
+                shift
+                ;;
+
+            # Other options
+            -*)
+                # Same error message as `grep` command.
+                echo "Invalid option -- '${1#-}'" >&2
+                __ttcp::usage
+                return 4
                 ;;
 
             # Other
             *)
+                # Show usage and exit
+                echo "Invalid argument -- '${1}'" >&2
                 __ttcp::usage
-                exit 0
+                return 4
                 ;;
 
         esac
     done
+    return 0
 }
 
 __ttcp::unspin () {

--- a/ttcp.sh
+++ b/ttcp.sh
@@ -134,8 +134,8 @@ __ttcp::is_env_ok () {
         fi
     done < <(echo "$_TTCP_DEPENDENCIES" | tr ' ' '\n')
 
-    [ -z "$TTCP_ID" ] && echo "Set environment variable (TTCP_ID)." >&2 && return -- -1
-    [ -z "$TTCP_PASSWORD" ] && echo "Set environment variable (TTCP_PASSWORD)." >&2 && return -- -1
+    [ -z "$TTCP_ID" ] && echo "Set environment variable (TTCP_ID) or give the ID by -i option." >&2 && return -- -1
+    [ -z "$TTCP_PASSWORD" ] && echo "Set environment variable (TTCP_PASSWORD) or give the password by -p option." >&2 && return -- -1
     return 0
 }
 

--- a/ttcp.sh
+++ b/ttcp.sh
@@ -14,7 +14,7 @@ _TTCP_DEPENDENCIES="${_TTCP_DEPENDENCIES:-yes openssl curl perl}"
 
 # Whare the last pasted content stored is.
 # It is re-used when you failed to get the remote content.
-TTCP_LASTPASTE_PATH="${TMPDIR}/lastPaste"
+TTCP_LASTPASTE_PATH_PREFIX="${TMPDIR}/lastPaste_"
 TTCP_ID_PREFIX="ttcopy"
 
 # Dependent services

--- a/ttcp.sh
+++ b/ttcp.sh
@@ -35,8 +35,10 @@ __ttcp::usage () {
     echo "  Usage: $_cmd [OPTIONS]"
     echo
     echo "  OPTIONS:"
-    echo "  -h, --help       Output a usage message and exit."
-    echo "  -V, --version    Output the version number of $_cmd and exit."
+    echo "  -h, --help                         Output a usage message and exit."
+    echo "  -V, --version                      Output the version number of $_cmd and exit."
+    echo "  -i ID, --id=ID                     Specify ID to identify the data."
+    echo "  -p PASSWORD, --password=PASSWORD   Specify Password to encrypt/decrypt the data."
 }
 
 __ttcp::opts () {
@@ -55,6 +57,14 @@ __ttcp::opts () {
                 __ttcp::version
                 exit 0
                 ;;
+            --id=*)
+                TTCP_ID="${1#--id=}"
+                shift
+                ;;
+            --password=*)
+                TTCP_PASSWORD="${1#--password=}"
+                shift
+                ;;
 
             # Short options
             -*)
@@ -66,8 +76,23 @@ __ttcp::opts () {
                     __ttcp::version
                     exit 0
                 fi
-                shift
+                if [[ "$1" =~ 'i' ]]; then
+                    TTCP_ID="$2"
+                    shift
+                    shift
+                elif [[ "$1" =~ 'p' ]]; then
+                    TTCP_PASSWORD="$2"
+                    shift
+                    shift
+                fi
                 ;;
+
+            # Other
+            *)
+                __ttcp::usage
+                exit 0
+                ;;
+
         esac
     done
 }

--- a/ttpaste.sh
+++ b/ttpaste.sh
@@ -13,6 +13,7 @@ trap "__ttcp::unspin; kill 0; exit 2" SIGHUP SIGINT SIGQUIT SIGTERM
 __ttcp::opts "$@"
 __ttcp::spin "Pasting..."
 
+TTCP_LASTPASTE_PATH="${TTCP_LASTPASTE_PATH_PREFIX}${TTCP_ID}"
 CLIP_BODY=$(curl --fail -so- "$TTCP_CLIP_NET/$TTCP_ID_PREFIX/$TTCP_ID" 2> /dev/null)
 if [ $? -ne 0 ]; then
     __ttcp::unspin
@@ -23,6 +24,7 @@ fi
 TRANS_URL=$(echo "$CLIP_BODY" |
                    # Use only (extended) regular expression compatible with POSIX.
                    sed 's/<[^>]*>//g' | grep -E "${TTCP_TRANSFER_SH}/[^/]+/.+" | head -n 1 2> /dev/null)
+
 
 if [ "$TRANS_URL" = "" ]; then
     [ -f "$TTCP_LASTPASTE_PATH" ] ||

--- a/ttpaste.sh
+++ b/ttpaste.sh
@@ -4,13 +4,14 @@
 # Based on http://stackoverflow.com/a/246128
 # then added zsh support from http://stackoverflow.com/a/23259585 .
 _TTCP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")"; pwd)"
-
 source "$_TTCP_DIR"/ttcp.sh
 
+# Option parser is called prior to is_env_ok
+# Because id/password might be given by user.
+__ttcp::opts "$@"
 __ttcp::is_env_ok || exit -1
 
 trap "__ttcp::unspin; kill 0; exit 2" SIGHUP SIGINT SIGQUIT SIGTERM
-__ttcp::opts "$@"
 __ttcp::spin "Pasting..."
 
 TTCP_LASTPASTE_PATH="${TTCP_LASTPASTE_PATH_PREFIX}${TTCP_ID}"

--- a/ttpaste.sh
+++ b/ttpaste.sh
@@ -9,6 +9,18 @@ source "$_TTCP_DIR"/ttcp.sh
 # Option parser is called prior to is_env_ok
 # Because id/password might be given by user.
 __ttcp::opts "$@"
+_opt_status=$?
+
+# There is invalid options/arguments.
+if [ $_opt_status -eq 4 ]; then
+    # Same as GNU sed.
+    exit 4
+
+# Shows usage or version number.
+elif [ $_opt_status -eq 254 ]; then
+    exit 0
+fi
+
 __ttcp::is_env_ok || exit -1
 
 trap "__ttcp::unspin; kill 0; exit 2" SIGHUP SIGINT SIGQUIT SIGTERM


### PR DESCRIPTION
New features
* `-i` and `--id` options.
  + User can specify temporal `TTCP_ID`.
* `-p` and `--password` options.
  + User can specify temporal `TTCP_PASSWORD`.

If this PR is merged, I suppose, the version will be `v1.1.0`.
How about following Semantic Versioning (http://semver.org/lang/ja/) ?
The rule like this.

* Major version up -- New features with NOT keeping backward compatibility.
* Minor version up -- New features with keeping backward compatibility.
* Patch version up -- Bug fix with keeping backward compatibility.