### PR TITLE
Arrange exit codes (#25)

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -42,17 +42,17 @@ dummyString () {
 
 test_copy_transfer_sh_dead () {
     echo "aaaa" | tr -d '\n' | TTCP_TRANSFER_SH="$TTCP_TRANSFER_SH_NG" ttcopy
-    assertEquals 128 $?
+    assertEquals 16 $?
 }
 
 test_copy_clip_net_dead () {
     echo "aaaa" | tr -d '\n' | TTCP_CLIP_NET="$TTCP_CLIP_NET_NG" ttcopy
-    assertEquals 129 $?
+    assertEquals 17 $?
 }
 
 test_paste_clip_net_dead () {
     TTCP_CLIP_NET="$TTCP_CLIP_NET_NG" ttpaste
-    assertEquals 129 $?
+    assertEquals 17 $?
 }
 
 # `netcat` is necessary to run this test.
@@ -61,23 +61,23 @@ test_paste_transfer_sh_dead () {
     # Run mock server to simulate c1ip.net with 10000 port.
     cl1pMockserver $port > /dev/null 2>&1 &
     TTCP_CLIP_NET="http://localhost:$port" TTCP_TRANSFER_SH="http://example.com" ttpaste
-    assertEquals 128 $?
+    assertEquals 16 $?
 }
 
 test_lack_dependency () {
     # It fails, if there is `hogehogeoppaipai` command.
     echo aaa | _TTCP_DEPENDENCIES="hogehogeoppaipai curl" ttcopy
-    assertEquals 255 $?
+    assertEquals 127 $?
 }
 
 test_unset_id () {
     echo aaa | TTCP_ID="" ttcopy
-    assertEquals 255 $?
+    assertEquals 3 $?
 }
 
 test_unset_password () {
     echo aaa | TTCP_PASSWORD="" ttcopy
-    assertEquals 255 $?
+    assertEquals 3 $?
 }
 
 test_version () {
@@ -202,35 +202,35 @@ test_id_pass_given_by_arg_error () {
 
     # Short option: password is empty
     echo AAA | ttcopy -i "dummy"
-    assertEquals 255 $?
+    assertEquals 3 $?
 
     # Long option: password is empty
     echo AAA | ttcopy --id=dummy
-    assertEquals 255 $?
+    assertEquals 3 $?
 
     # Short option: ID is empty
     echo AAA | ttcopy -p dummy
-    assertEquals 255 $?
+    assertEquals 3 $?
 
     # Long option: ID is empty
     echo AAA | ttcopy --password=dummy
-    assertEquals 255 $?
+    assertEquals 3 $?
 
     # Short option: password is empty
     ttpaste -i dummy
-    assertEquals 255 $?
+    assertEquals 3 $?
 
     # Long option: password is empty
     ttpaste --id=dummy
-    assertEquals 255 $?
+    assertEquals 3 $?
 
     # Short option: ID is empty
     ttpaste -p dummy
-    assertEquals 255 $?
+    assertEquals 3 $?
 
     # Long option: ID is empty
     ttpaste --password=dummy
-    assertEquals 255 $?
+    assertEquals 3 $?
 }
 
 test_simple_string () {

--- a/ttcopy.sh
+++ b/ttcopy.sh
@@ -20,7 +20,7 @@ elif [ $_opt_status -eq 254 ]; then
     exit 0
 fi
 
-__ttcp::is_env_ok
+__ttcp::check_env
 
 trap "__ttcp::unspin; kill 0; exit $_TTCP_EINTR" SIGHUP SIGINT SIGQUIT SIGTERM
 __ttcp::spin "Copying..."

--- a/ttcopy.sh
+++ b/ttcopy.sh
@@ -6,20 +6,9 @@
 _TTCP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")"; pwd)"
 source "$_TTCP_DIR"/ttcp.sh
 
-# Option parser is called prior to is_env_ok
+# __ttcp::opts is called prior to __ttcp::check_env
 # Because id/password might be given by user.
 __ttcp::opts "$@"
-_opt_status=$?
-
-# There is invalid options/arguments.
-if [ $_opt_status -eq 4 ]; then
-    exit $_TTCP_EINVAL
-
-# Shows usage or version number.
-elif [ $_opt_status -eq 254 ]; then
-    exit 0
-fi
-
 __ttcp::check_env
 
 trap "__ttcp::unspin; kill 0; exit $_TTCP_EINTR" SIGHUP SIGINT SIGQUIT SIGTERM

--- a/ttcp.sh
+++ b/ttcp.sh
@@ -83,11 +83,11 @@ __ttcp::opts () {
             # Long options
             --help)
                 __ttcp::usage
-                return 254
+                exit 0
                 ;;
             --version)
                 __ttcp::version
-                return 254
+                exit 0
                 ;;
             --id=*)
                 TTCP_ID="${1#--id=}"
@@ -103,13 +103,13 @@ __ttcp::opts () {
                 # For --help
                 if [[ "$1" =~ 'h' ]]; then
                     __ttcp::usage
-                    return 254
+                    exit 0
                 fi
 
                 # For --version
                 if [[ "$1" =~ 'V' ]]; then
                     __ttcp::version
-                    return 254
+                    exit 0
                 fi
 
                 # For --id
@@ -132,7 +132,7 @@ __ttcp::opts () {
                 # Same error message as `grep` command.
                 echo "Invalid option -- '${1#-}'" >&2
                 __ttcp::usage
-                return 4
+                exit $_TTCP_EINVAL
                 ;;
 
             # Other
@@ -140,7 +140,7 @@ __ttcp::opts () {
                 # Show usage and exit
                 echo "Invalid argument -- '${1}'" >&2
                 __ttcp::usage
-                return 4
+                exit $_TTCP_EINVAL
                 ;;
 
         esac

--- a/ttcp.sh
+++ b/ttcp.sh
@@ -174,7 +174,7 @@ __ttcp::spin () {
     _TTCP_SPIN_PID=$!
 }
 
-__ttcp::is_env_ok () {
+__ttcp::check_env () {
     while read cmd ; do
         type $cmd > /dev/null 2>&1
         if [ $? -ne 0 ]; then

--- a/ttcp.sh
+++ b/ttcp.sh
@@ -4,6 +4,38 @@
 # MAJOR.MINOR.PATCH
 readonly TTCP_VERSION="1.1.0"
 
+# Error constants
+# ===============
+
+# Undefined or General errors
+readonly _TTCP_EUNDEF=1
+
+# TTCP_ID/TTCP_PASSWORD is undefined
+readonly _TTCP_ENOCRED=3
+
+# Invalid option/argument
+readonly _TTCP_EINVAL=4
+
+# Nothing has been copied yet
+readonly _TTCP_ENOCONTENT=5
+
+# openssl got something wrong.
+readonly _TTCP_EENCRYPT=8
+
+# Necessary commands are not found
+readonly _TTCP_ENOCMD=127
+
+# Terminated by Ctl-C
+readonly _TTCP_EINTR=130
+
+# Failed to upload/download the content
+readonly _TTCP_ECONTTRANS=16
+
+# Failed to get the content url
+readonly _TTCP_ECONTURL=17
+
+# ===============
+
 # Portable and reliable way to get the directory of this script.
 # Based on http://stackoverflow.com/a/246128
 # then added zsh support from http://stackoverflow.com/a/23259585 .
@@ -147,14 +179,16 @@ __ttcp::is_env_ok () {
         type $cmd > /dev/null 2>&1
         if [ $? -ne 0 ]; then
             echo "$cmd is required to work." >&2
-            # `return -1` does not work in particular situation. `-1` is recognized as an option.
-            # After `--`, any arguments are not interpreted as option.
-            return -- -1
+            exit $_TTCP_ENOCMD
         fi
     done < <(echo "$_TTCP_DEPENDENCIES" | tr ' ' '\n')
 
-    [ -z "$TTCP_ID" ] && echo "Set environment variable (TTCP_ID) or give the ID by -i option." >&2 && return -- -1
-    [ -z "$TTCP_PASSWORD" ] && echo "Set environment variable (TTCP_PASSWORD) or give the password by -p option." >&2 && return -- -1
+    [ -z "$TTCP_ID" ] && \
+        echo "Set environment variable (TTCP_ID) or give the ID by -i option." >&2 && \
+        exit $_TTCP_ENOCRED
+    [ -z "$TTCP_PASSWORD" ] && \
+        echo "Set environment variable (TTCP_PASSWORD) or give the password by -p option." >&2 && \
+        exit $_TTCP_ENOCRED
     return 0
 }
 

--- a/ttpaste.sh
+++ b/ttpaste.sh
@@ -14,16 +14,16 @@ _opt_status=$?
 # There is invalid options/arguments.
 if [ $_opt_status -eq 4 ]; then
     # Same as GNU sed.
-    exit 4
+    exit $_TTCP_EINVAL
 
 # Shows usage or version number.
 elif [ $_opt_status -eq 254 ]; then
     exit 0
 fi
 
-__ttcp::is_env_ok || exit -1
+__ttcp::is_env_ok
 
-trap "__ttcp::unspin; kill 0; exit 2" SIGHUP SIGINT SIGQUIT SIGTERM
+trap "__ttcp::unspin; kill 0; exit $_TTCP_EINTR" SIGHUP SIGINT SIGQUIT SIGTERM
 __ttcp::spin "Pasting..."
 
 TTCP_LASTPASTE_PATH="${TTCP_LASTPASTE_PATH_PREFIX}${TTCP_ID}"
@@ -31,7 +31,7 @@ CLIP_BODY=$(curl --fail -so- "$TTCP_CLIP_NET/$TTCP_ID_PREFIX/$TTCP_ID" 2> /dev/n
 if [ $? -ne 0 ]; then
     __ttcp::unspin
     echo "Failed to get the content url" >&2
-    exit 129
+    exit $_TTCP_ECONTURL
 fi
 
 TRANS_URL=$(echo "$CLIP_BODY" |
@@ -43,7 +43,7 @@ if [ "$TRANS_URL" = "" ]; then
     [ -f "$TTCP_LASTPASTE_PATH" ] ||
         { __ttcp::unspin;
           echo "Nothing has been copied yet." >&2;
-          exit 1; }
+          exit $_TTCP_ENOCONTENT; }
 
     __ttcp::unspin
     echo "(Pasting the last paste)" >&2
@@ -54,7 +54,7 @@ curl --fail -so- "$TRANS_URL" > "$TTCP_LASTPASTE_PATH" 2> /dev/null
 if [ $? -ne 0 ]; then
     __ttcp::unspin
     echo "Failed to get the content" >&2
-    exit 128
+    exit $_TTCP_ECONTTRANS
 fi
 
 __ttcp::unspin

--- a/ttpaste.sh
+++ b/ttpaste.sh
@@ -21,7 +21,7 @@ elif [ $_opt_status -eq 254 ]; then
     exit 0
 fi
 
-__ttcp::is_env_ok
+__ttcp::check_env
 
 trap "__ttcp::unspin; kill 0; exit $_TTCP_EINTR" SIGHUP SIGINT SIGQUIT SIGTERM
 __ttcp::spin "Pasting..."

--- a/ttpaste.sh
+++ b/ttpaste.sh
@@ -6,21 +6,9 @@
 _TTCP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")"; pwd)"
 source "$_TTCP_DIR"/ttcp.sh
 
-# Option parser is called prior to is_env_ok
+# __ttcp::opts is called prior to __ttcp::check_env
 # Because id/password might be given by user.
 __ttcp::opts "$@"
-_opt_status=$?
-
-# There is invalid options/arguments.
-if [ $_opt_status -eq 4 ]; then
-    # Same as GNU sed.
-    exit $_TTCP_EINVAL
-
-# Shows usage or version number.
-elif [ $_opt_status -eq 254 ]; then
-    exit 0
-fi
-
 __ttcp::check_env
 
 trap "__ttcp::unspin; kill 0; exit $_TTCP_EINTR" SIGHUP SIGINT SIGQUIT SIGTERM


### PR DESCRIPTION
Closes #25

I made a change to `is_env_ok()` to exit the program immediately so that we can simply output in accordance with the reason of the failure.
Then I changed the its name to `check_env()` because it is no longer be the function to express the condition.