### PR TITLE
Feature/proxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
+
 sudo: required
+
+services:
+  - docker
 
 os:
   - linux

--- a/README.md
+++ b/README.md
@@ -106,6 +106,63 @@ $ ttpaste | file -
 /dev/stdin: JPEG image data, JFIF standard 1.01
 ```
 
+# Features
+
+## Options
+
+`ttcopy` and `ttpaste` commands support following options.
+
+```
+$ ttcopy --help
+  OPTIONS:
+  -h, --help                         Output a usage message and exit.
+  -V, --version                      Output the version number of ttcopy and exit.
+  -i ID, --id=ID                     Specify ID to identify the data.
+  -p PASSWORD, --password=PASSWORD   Specify password to encrypt/decrypt the data.
+```
+
+Use specific ID and password instead of `TTCP_ID` and `TTCP_PASSWORD`.
+
+```
+$ seq 10 | ttcopy -i abcdef -p ghijklmn
+Copied!
+```
+
+```
+$ ttpaste -i abcdef -p ghijklmn
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+```
+
+## Copy/Paste through proxy server
+
+Commands load shell variable `TTCP_PROXY` as their proxy server for connection.
+
+```sh
+$ echo ABCDEFG | TTCP_PROXY="http://example.proxy.server1.com:1234" ttcopy
+```
+
+```sh
+$ TTCP_PROXY="http://example.proxy.server2.com:5678" ttpaste
+ABCDEFG
+```
+
+It is helpful to edit `.bashrc` or `.zshrc` if you are always using specific proxy server.
+
+```sh
+...
+export TTCP_PROXY="http://example.proxy.server1.com:1234"
+...
+```
+
 ## LICENSE
 
 This is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/bin/ttcopy
+++ b/bin/ttcopy
@@ -15,12 +15,14 @@ __ttcp::check_env
 trap "__ttcp::unspin; kill 0; exit $_TTCP_EINTR" SIGHUP SIGINT SIGQUIT SIGTERM
 __ttcp::spin "Copying..."
 
+_HTTP_CLIENT="$(__ttcp::http_client)"
+
 TTCP_ID_CLIP="$(echo "${TTCP_ID}${TTCP_SALT1}" | __ttcp::hash)"
 TTCP_PASSWORD_CLIP="$(echo "${TTCP_PASSWORD}${TTCP_SALT1}" | __ttcp::hash)"
 TTCP_ID_TRANS="$(echo "${TTCP_ID}${TTCP_SALT2}" | __ttcp::hash)"
 TTCP_PASSWORD_TRANS="$(echo "${TTCP_PASSWORD}${TTCP_ID}${TTCP_SALT2}" | __ttcp::hash)"
 
-TRANS_URL=$(curl -so- --fail --upload-file <(cat | __ttcp::encode "${TTCP_PASSWORD_TRANS}") $TTCP_TRANSFER_SH/$TTCP_ID_TRANS );
+TRANS_URL=$(${_HTTP_CLIENT} -so- --fail --upload-file <(cat | __ttcp::encode "${TTCP_PASSWORD_TRANS}") $TTCP_TRANSFER_SH/$TTCP_ID_TRANS );
 
 if [ $? -ne 0 ]; then
     __ttcp::unspin
@@ -36,7 +38,7 @@ if [ "$ENCRYPTED_TRANS_URL" = "" ]; then
     exit $_TTCP_EENCODE
 fi
 
-curl -s -X POST "$TTCP_CLIP_NET/$TTCP_ID_PREFIX/$TTCP_ID_CLIP" --fail --data "content=TTCP[$ENCRYPTED_TRANS_URL]" > /dev/null
+${_HTTP_CLIENT} -s -X POST "$TTCP_CLIP_NET/$TTCP_ID_PREFIX/$TTCP_ID_CLIP" --fail --data "content=TTCP[$ENCRYPTED_TRANS_URL]" > /dev/null
 
 if [ $? -ne 0 ]; then
     __ttcp::unspin

--- a/bin/ttpaste
+++ b/bin/ttpaste
@@ -25,6 +25,8 @@ check_decoding_failure() {
     fi
 }
 
+_HTTP_CLIENT="$(__ttcp::http_client)"
+
 TTCP_ID_CLIP="$(echo "${TTCP_ID}${TTCP_SALT1}" | __ttcp::hash)"
 TTCP_PASSWORD_CLIP="$(echo "${TTCP_PASSWORD}${TTCP_SALT1}" | __ttcp::hash)"
 # TTCP_ID_TRANS="$(echo "${TTCP_ID}${TTCP_SALT2}" | __ttcp::hash)"
@@ -32,7 +34,7 @@ TTCP_PASSWORD_TRANS="$(echo "${TTCP_PASSWORD}${TTCP_ID}${TTCP_SALT2}" | __ttcp::
 
 TTCP_LASTPASTE_PATH="${TTCP_LASTPASTE_PATH_PREFIX}${TTCP_ID}"
 TTCP_LASTURL_PATH="${TTCP_LASTPASTE_PATH_PREFIX}${TTCP_ID}_url"
-CLIP_BODY=$(curl --fail -so- "$TTCP_CLIP_NET/$TTCP_ID_PREFIX/$TTCP_ID_CLIP" 2> /dev/null)
+CLIP_BODY=$(${_HTTP_CLIENT} --fail -so- "$TTCP_CLIP_NET/$TTCP_ID_PREFIX/$TTCP_ID_CLIP" 2> /dev/null)
 
 if [ $? -ne 0 ]; then
     __ttcp::unspin
@@ -70,7 +72,7 @@ echo "$ENCRYPTED_TRANS_URL" > "${TTCP_LASTURL_PATH}"
 TRANS_URL="$(echo $ENCRYPTED_TRANS_URL | __ttcp::base64dec | __ttcp::decode "$TTCP_PASSWORD_CLIP")"
 check_decoding_failure "$?"
 
-curl --fail -so- "$TRANS_URL" > "$TTCP_LASTPASTE_PATH" 2> /dev/null
+${_HTTP_CLIENT} --fail -so- "$TRANS_URL" > "$TTCP_LASTPASTE_PATH" 2> /dev/null
 if [ $? -ne 0 ]; then
     __ttcp::unspin
     echo "Failed to get the content" >&2

--- a/lib/ttcp
+++ b/lib/ttcp
@@ -48,6 +48,8 @@ _TTCP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")"; cd ..; pwd)"
 # Dependent commands (non POSIX commands)
 _TTCP_DEPENDENCIES="${_TTCP_DEPENDENCIES:-yes openssl curl perl gzip}"
 
+_TTCP_HTTP_CLIENT="${_TTCP_HTTP_CLIENT:-curl}"
+
 # Algorithm for encoding data
 _TTCP_ENCRYPT_ALGORITHM="${_TTCP_ENCRYPT_ALGORITHM:-aes-256-cbc}"
 
@@ -205,6 +207,15 @@ __ttcp::check_env () {
         echo "Set environment variable (TTCP_PASSWORD) or give the password by -p option." >&2 && \
         exit $_TTCP_ENOCRED
     return 0
+}
+
+__ttcp::http_client () {
+    # If TTCP_PROXY is undefined or empty...
+    if [ -z "${TTCP_PROXY}" ]; then
+        echo "${_TTCP_HTTP_CLIENT}"
+    else
+        echo "${_TTCP_HTTP_CLIENT} -x ${TTCP_PROXY}"
+    fi
 }
 
 # key -- $1

--- a/test/test.sh
+++ b/test/test.sh
@@ -43,10 +43,6 @@ tearDown(){
 # Q. Why `nc` is not used for it?
 # A. `nc` does not support proxy fowarding with HTTPS protocol.
 createProxyServer() {
-    # If there is no "greymd/ttcopy-test-proxy" image, pull it.
-    if ! ( docker images --format '{{.Repository}}' | grep -qE "^${DOCKER_HUB_REPOSITORY}$" ); then
-        docker pull ${DOCKER_HUB_REPOSITORY}
-    fi
     docker run -d --name $CONTAINER_NAME -p 3128:3128 ${DOCKER_HUB_REPOSITORY} > /dev/null
     sleep 10 # Wait proxy server starts safely.
 }

--- a/test/test.sh
+++ b/test/test.sh
@@ -22,7 +22,7 @@ export TTCP_PASSWORD=""
 
 # Docker container which is used for proxy server.
 readonly CONTAINER_NAME="ttcopy-test-proxy"
-readonly DOCKER_HUB_REPOSITORY="greymd/$CONTAINER_NAME"
+readonly DOCKER_HUB_REPOSITORY="sameersbn/squid"
 
 # It is called before each tests.
 setUp () {

--- a/test/test.sh
+++ b/test/test.sh
@@ -29,9 +29,16 @@ setUp () {
     # Set random id/password
     export TTCP_ID="$(cat /dev/urandom | grep -ao '[a-zA-Z0-9]' | tr -d '\n' | fold -w 128 | head -n 1)"
     export TTCP_PASSWORD="$(cat /dev/urandom | grep -ao '[a-zA-Z0-9]' | tr -d '\n' | fold -w 128 | head -n 1)"
+    echo ">>>>>>>>>>" >&2
 }
 
-# Mockserver for c1ip.net
+# It is called after each tests.
+tearDown(){
+    echo >&2
+    echo "<<<<<<<<<<" >&2
+    echo >&2
+}
+
 # Create proxy server with squid.
 # Q. Why `nc` is not used for it?
 # A. `nc` does not support proxy fowarding with HTTPS protocol.
@@ -49,6 +56,8 @@ killProxyServer() {
     docker kill $CONTAINER_NAME  &> /dev/null
     docker rm $CONTAINER_NAME  &> /dev/null
 }
+
+# Mockserver for cl1p.net
 # It returns url `http://example.com/URL404/file.txt`
 # which is supposed to have 404 http status.
 cl1pMockserver () {

--- a/test/test_files/Dockerfile
+++ b/test/test_files/Dockerfile
@@ -1,0 +1,8 @@
+FROM centos:7
+MAINTAINER ttcopy developers <https://github.com/greymd/ttcopy>
+RUN yum install -y squid
+
+# Default port of squid
+EXPOSE 3128
+
+CMD ["/usr/sbin/squid","-N"]

--- a/test/test_files/Dockerfile
+++ b/test/test_files/Dockerfile
@@ -1,8 +1,0 @@
-FROM centos:7
-MAINTAINER ttcopy developers <https://github.com/greymd/ttcopy>
-RUN yum install -y squid
-
-# Default port of squid
-EXPOSE 3128
-
-CMD ["/usr/sbin/squid","-N"]


### PR DESCRIPTION
New features for #27 

* Support `TTCP_PROXY` variable.
* CI uses docker to simulate proxy server.
  + New `Dockerfile` is added for test.
  + https://hub.docker.com/r/greymd/ttcopy-test-proxy/~/settings/collaborators/
* Update `README.md`
* Refactoring `test.sh`
  + I believe results became more readable one.

After this merge, I think the version will be `v2.2.0`.