### PR TITLE
Feature/credental init

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,14 @@ env:
   - SH=zsh
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then if [[ ! $(which $SH) ]] ; then sudo apt-get -qq update        ; fi ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then if [[ ! $(which $SH) ]] ; then sudo apt-get install -y $SH    ; fi ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then if [[ ! $(which nc) ]]  ; then sudo apt-get install -y netcat ; fi ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]   ; then if [[ ! $(which $SH) ]] ; then brew update                    ; fi ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]   ; then if [[ ! $(which $SH) ]] ; then brew install $SH               ; fi ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]   ; then if [[ ! $(which nc) ]]  ; then brew install netcat            ; fi ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then if [[ ! $(which $SH) ]]    ; then sudo apt-get -qq update        ; fi ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then if [[ ! $(which $SH) ]]    ; then sudo apt-get install -y $SH    ; fi ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then if [[ ! $(which nc) ]]     ; then sudo apt-get install -y netcat ; fi ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then if [[ ! $(which expect) ]] ; then sudo apt-get install -y expect ; fi ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]   ; then if [[ ! $(which $SH) ]]    ; then brew update                    ; fi ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]   ; then if [[ ! $(which $SH) ]]    ; then brew install $SH               ; fi ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]   ; then if [[ ! $(which nc) ]]     ; then brew install netcat            ; fi ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]   ; then if [[ ! $(which expect) ]] ; then brew install expect            ; fi ; fi
 
 before_script:
   - export TMPDIR=$TRAVIS_BUILD_DIR/tmp # Default TMPDIR is not writable on Travis CI

--- a/README.md
+++ b/README.md
@@ -15,32 +15,32 @@ Provide copying and pasting within multiple hosts through the Web.
   * zsh (tested ver: 4.3, 5.0)
   * bash (tested ver: 3.2, 4.2)
 
-## Dependent commands
+## Requirements
   * openssl
   * curl
 
 # Installation
-First of all, please prepare ID and Password **as you like**.
-Be lazy! You are **NOT** required to register them on any services.
-The data you copied can be pasted within the hosts having same ID/Password.
-
-After that, set up `ttcopy` on the hosts which you want to make share same data.
+Set up `ttcopy` on the hosts which you want to make share same data.
 Please follow the following instructions to install it.
 
 ## With [zplug](https://zplug.sh) (for zsh users)
 
 If you are using zplug, it is easy and recommended way.
-Add those lines to `.zshrc`.
+Add this line to `.zshrc`.
 
 ```sh
-# Set ID and Password you decided.
-export TTCP_ID="your_id"
-export TTCP_PASSWORD="your_password"
-
 zplug "greymd/ttcopy"
 ```
 
 That's all 🎉.
+
+## With [Antigen](http://antigen.sharats.me/) (for zsh users)
+This way is almost same as other plugin managers for zsh.
+For example, add this line to `.zshrc` if you are using [Antigen](http://antigen.sharats.me/).
+
+```sh
+antigen bundle "greymd/ttcopy"
+```
 
 ## Manual Installation
 
@@ -57,10 +57,6 @@ $ git clone https://github.com/greymd/ttcopy.git ~/ttcopy
 Add following lines.
 
 ```sh
-# Set ID and Password you decided.
-export TTCP_ID="your_id"
-export TTCP_PASSWORD="your_password"
-
 source ~/ttcopy/ttcp_activate.sh
 ```
 
@@ -76,6 +72,23 @@ For example,
 cp -rf ~/ttcopy/bin ~/ttcopy/lib /usr/local
 
 echo "export PATH=$PATH:/usr/local/bin" >> ~/.zshrc" # if you need
+```
+
+# Configuration
+First of all, `ttcopy` command displays the screen to set default ID/Password.
+Please 
+ID and Password **as you like**. Be lazy! You are **NOT** required to register them on any services.
+The data you copied can be pasted within the hosts having same ID/Password.
+
+```sh
+$ ttcopy
+Set default ID/Password.
+Enter ID for ttcopy/ttpaste:myid001   #<= Enter your ID ("myid001" is just an example).
+Enter password for ttcopy/ttpaste:    #<= Enter your password.
+Enter same password again:            #<= Enter again.
+
+Created credential file '/Users/user/.ttcopy/config'
+Execute 'ttcopy --init' to show this screen again.
 ```
 
 # Examples
@@ -114,14 +127,17 @@ $ ttpaste | file -
 
 ```
 $ ttcopy --help
+  Usage: ttcopy [OPTIONS]
+
   OPTIONS:
   -h, --help                         Output a usage message and exit.
   -V, --version                      Output the version number of ttcopy and exit.
   -i ID, --id=ID                     Specify ID to identify the data.
   -p PASSWORD, --password=PASSWORD   Specify password to encrypt/decrypt the data.
+  --init                             Set default ID and password.
 ```
 
-Use specific ID and password instead of `TTCP_ID` and `TTCP_PASSWORD`.
+Use non-default ID and password.
 
 ```
 $ seq 10 | ttcopy -i abcdef -p ghijklmn
@@ -155,12 +171,10 @@ $ TTCP_PROXY="http://example.proxy.server2.com:5678" ttpaste
 ABCDEFG
 ```
 
-It is helpful to edit `.bashrc` or `.zshrc` if you are always using specific proxy server.
+It is helpful to add this line to `.bashrc` or `.zshrc` if you are always using specific proxy server.
 
 ```sh
-...
 export TTCP_PROXY="http://example.proxy.server1.com:1234"
-...
 ```
 
 ## LICENSE

--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ The data you copied can be pasted within the hosts having same ID and Password.
 ```sh
 $ ttcopy
 Set default ID/Password.
-Enter ID for ttcopy/ttpaste:myid001   #<= Enter your ID ("myid001" is just an example).
+Enter ID for ttcopy/ttpaste: myid001   #<= Enter your ID ("myid001" is just an example).
 Enter password for ttcopy/ttpaste:    #<= Enter your password.
 Enter same password again:            #<= Enter again.
 
-Created credential file '/Users/user/.ttcopy/config'
+Created credential file '/home/user/.ttcopy/config'
 Execute 'ttcopy --init' to show this screen again.
 ```
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Enter ID for ttcopy/ttpaste: myid001   #<= Enter your ID ("myid001" is just an e
 Enter password for ttcopy/ttpaste:    #<= Enter your password.
 Enter same password again:            #<= Enter again.
 
-Created credential file '/home/user/.ttcopy/config'
+Created credential file '/home/user/.config/ttcopy/config'
 Execute 'ttcopy --init' to show this screen again.
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ zplug "greymd/ttcopy"
 That's all 🎉.
 
 ## With [Antigen](http://antigen.sharats.me/) (for zsh users)
-This way is almost same as other plugin managers for zsh.
+The above way is almost same for the other plugin managers.
 For example, add this line to `.zshrc` if you are using [Antigen](http://antigen.sharats.me/).
 
 ```sh
@@ -75,10 +75,9 @@ echo "export PATH=$PATH:/usr/local/bin" >> ~/.zshrc" # if you need
 ```
 
 # Configuration
-First of all, `ttcopy` command displays the screen to set default ID/Password.
-Please 
-ID and Password **as you like**. Be lazy! You are **NOT** required to register them on any services.
-The data you copied can be pasted within the hosts having same ID/Password.
+First of all, `ttcopy` command displays the screen to let you set default ID and Password.
+Please prepare ID and Password **as you like**. Be lazy! You are **NOT** required to register them on any services.
+The data you copied can be pasted within the hosts having same ID and Password.
 
 ```sh
 $ ttcopy

--- a/bin/ttcopy
+++ b/bin/ttcopy
@@ -7,11 +7,16 @@
 _TTCP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")"; cd ..; pwd)"
 source "$_TTCP_DIR"/lib/ttcp
 
-# __ttcp::opts is called prior to __ttcp::check_env
-# Because id/password might be given by user.
+# Get options
 __ttcp::opts "$@"
-__ttcp::is_credential_valid || __ttcp::load_config || __ttcp::init
-__ttcp::check_env
+# Check whether TTCP_ID and TTCP_PASSWORD are set or not.
+__ttcp::is_credential_valid || \
+    # If not, check config file and load it.
+    { __ttcp::check_config && __ttcp::load_config; } || \
+    # If config could not be loaded, initial screen is shown.
+    __ttcp::init
+
+__ttcp::is_dependency_installed
 
 trap "__ttcp::unspin; kill 0; exit $_TTCP_EINTR" SIGHUP SIGINT SIGQUIT SIGTERM
 __ttcp::spin "Copying..."

--- a/bin/ttcopy
+++ b/bin/ttcopy
@@ -10,6 +10,7 @@ source "$_TTCP_DIR"/lib/ttcp
 # __ttcp::opts is called prior to __ttcp::check_env
 # Because id/password might be given by user.
 __ttcp::opts "$@"
+__ttcp::is_credential_valid || __ttcp::load_config || __ttcp::init
 __ttcp::check_env
 
 trap "__ttcp::unspin; kill 0; exit $_TTCP_EINTR" SIGHUP SIGINT SIGQUIT SIGTERM

--- a/bin/ttcopy
+++ b/bin/ttcopy
@@ -18,10 +18,9 @@ __ttcp::spin "Copying..."
 
 _HTTP_CLIENT="$(__ttcp::http_client)"
 
-TTCP_ID_CLIP="$(echo "${TTCP_ID}${TTCP_SALT1}" | __ttcp::hash)"
-TTCP_PASSWORD_CLIP="$(echo "${TTCP_PASSWORD}${TTCP_SALT1}" | __ttcp::hash)"
-TTCP_ID_TRANS="$(echo "${TTCP_ID}${TTCP_SALT2}" | __ttcp::hash)"
-TTCP_PASSWORD_TRANS="$(echo "${TTCP_PASSWORD}${TTCP_ID}${TTCP_SALT2}" | __ttcp::hash)"
+# Following credentials will be prepared.
+# TTCP_ID_CLIP, TTCP_PASSWORD_CLIP, TTCP_ID_TRANS, TTCP_PASSWORD_TRANS
+__ttcp::generate_credentials
 
 TRANS_URL=$(${_HTTP_CLIENT} -so- --fail --upload-file <(cat | __ttcp::encode "${TTCP_PASSWORD_TRANS}") $TTCP_TRANSFER_SH/$TTCP_ID_TRANS );
 

--- a/bin/ttpaste
+++ b/bin/ttpaste
@@ -28,10 +28,9 @@ check_decoding_failure() {
 
 _HTTP_CLIENT="$(__ttcp::http_client)"
 
-TTCP_ID_CLIP="$(echo "${TTCP_ID}${TTCP_SALT1}" | __ttcp::hash)"
-TTCP_PASSWORD_CLIP="$(echo "${TTCP_PASSWORD}${TTCP_SALT1}" | __ttcp::hash)"
-# TTCP_ID_TRANS="$(echo "${TTCP_ID}${TTCP_SALT2}" | __ttcp::hash)"
-TTCP_PASSWORD_TRANS="$(echo "${TTCP_PASSWORD}${TTCP_ID}${TTCP_SALT2}" | __ttcp::hash)"
+# Following credentials will be prepared.
+# TTCP_ID_CLIP, TTCP_PASSWORD_CLIP, TTCP_ID_TRANS, TTCP_PASSWORD_TRANS
+__ttcp::generate_credentials
 
 TTCP_LASTPASTE_PATH="${TTCP_LASTPASTE_PATH_PREFIX}${TTCP_ID}"
 TTCP_LASTURL_PATH="${TTCP_LASTPASTE_PATH_PREFIX}${TTCP_ID}_url"

--- a/bin/ttpaste
+++ b/bin/ttpaste
@@ -10,6 +10,7 @@ source "$_TTCP_DIR"/lib/ttcp
 # __ttcp::opts is called prior to __ttcp::check_env
 # Because id/password might be given by user.
 __ttcp::opts "$@"
+__ttcp::is_credential_valid || __ttcp::load_config || __ttcp::init
 __ttcp::check_env
 
 trap "__ttcp::unspin; kill 0; exit $_TTCP_EINTR" SIGHUP SIGINT SIGQUIT SIGTERM

--- a/bin/ttpaste
+++ b/bin/ttpaste
@@ -7,11 +7,16 @@
 _TTCP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")"; cd ..; pwd)"
 source "$_TTCP_DIR"/lib/ttcp
 
-# __ttcp::opts is called prior to __ttcp::check_env
-# Because id/password might be given by user.
+# Get options
 __ttcp::opts "$@"
-__ttcp::is_credential_valid || __ttcp::load_config || __ttcp::init
-__ttcp::check_env
+# Check whether TTCP_ID and TTCP_PASSWORD are set or not.
+__ttcp::is_credential_valid || \
+    # If not, check config file and load it.
+    { __ttcp::check_config && __ttcp::load_config; } || \
+    # If config could not be loaded, initial screen is shown.
+    __ttcp::init
+
+__ttcp::is_dependency_installed
 
 trap "__ttcp::unspin; kill 0; exit $_TTCP_EINTR" SIGHUP SIGINT SIGQUIT SIGTERM
 __ttcp::spin "Pasting..."

--- a/lib/ttcp
+++ b/lib/ttcp
@@ -276,7 +276,8 @@ __ttcp::init () {
     TTCP_PASSWORD="$_given_password1"
     __ttcp::generate_credentials
 
-    echo "TTCP_ID_CLIP=$TTCP_ID_CLIP" > $_TTCP_CONFIG_FILE
+    echo "TTCP_ID=$TTCP_ID" >> $_TTCP_CONFIG_FILE
+    echo "TTCP_ID_CLIP=$TTCP_ID_CLIP" >> $_TTCP_CONFIG_FILE
     echo "TTCP_PASSWORD_CLIP=$TTCP_PASSWORD_CLIP" >> $_TTCP_CONFIG_FILE
     echo "TTCP_ID_TRANS=$TTCP_ID_TRANS" >> $_TTCP_CONFIG_FILE
     echo "TTCP_PASSWORD_TRANS=$TTCP_PASSWORD_TRANS" >> $_TTCP_CONFIG_FILE
@@ -296,10 +297,11 @@ __ttcp::load_config () {
     local _file="${_TTCP_CONFIG_FILE:-$1}"
     __ttcp::check_config
     if [ $? -eq 0 ]; then
-        TTCP_ID_CLIP="$(cat "$_file"        | perl -nle '$. ==  1 && print' | sed 's/^TTCP_ID_CLIP=//')"
-        TTCP_PASSWORD_CLIP="$(cat "$_file"  | perl -nle '$. ==  2 && print' | sed 's/^TTCP_PASSWORD_CLIP=//')"
-        TTCP_ID_TRANS="$(cat "$_file"       | perl -nle '$. ==  3 && print' | sed 's/^TTCP_ID_TRANS=//')"
-        TTCP_PASSWORD_TRANS="$(cat "$_file" | perl -nle '$. ==  4 && print' | sed 's/^TTCP_PASSWORD_TRANS=//')"
+        TTCP_ID="$(cat "$_file"             | head -n 1 | tail -n 1 | sed 's/^TTCP_ID=//')"
+        TTCP_ID_CLIP="$(cat "$_file"        | head -n 2 | tail -n 1 | sed 's/^TTCP_ID_CLIP=//')"
+        TTCP_PASSWORD_CLIP="$(cat "$_file"  | head -n 3 | tail -n 1 | sed 's/^TTCP_PASSWORD_CLIP=//')"
+        TTCP_ID_TRANS="$(cat "$_file"       | head -n 4 | tail -n 1 | sed 's/^TTCP_ID_TRANS=//')"
+        TTCP_PASSWORD_TRANS="$(cat "$_file" | head -n 5 | tail -n 1 | sed 's/^TTCP_PASSWORD_TRANS=//')"
     else
         return 1
     fi
@@ -307,15 +309,16 @@ __ttcp::load_config () {
 
 # Config file format: ~/.ttcopy/config
 # -------------------------------------------------
-# Line1:TTCP_ID_CLIP=...
-# Line2:TTCP_PASSWORD_CLIP=...
-# Line3:TTCP_ID_TRANS=...
-# Line4:TTCP_PASSWORD_TRANS=...
+# Line1:TTCP_ID=...
+# Line2:TTCP_ID_CLIP=...
+# Line3:TTCP_PASSWORD_CLIP=...
+# Line4:TTCP_ID_TRANS=...
+# Line5:TTCP_PASSWORD_TRANS=...
 # <EOF>
 # -------------------------------------------------
 __ttcp::check_config () {
     local _file="${_TTCP_CONFIG_FILE:-$1}"
-    local _records="TTCP_ID_CLIP TTCP_PASSWORD_CLIP TTCP_ID_TRANS TTCP_PASSWORD_TRANS"
+    local _records="TTCP_ID TTCP_ID_CLIP TTCP_PASSWORD_CLIP TTCP_ID_TRANS TTCP_PASSWORD_TRANS"
 
     # Check existence of the file.
     if [ ! -e "$_file" ]; then

--- a/lib/ttcp
+++ b/lib/ttcp
@@ -214,6 +214,13 @@ __ttcp::spin () {
     _TTCP_SPIN_PID=$!
 }
 
+__ttcp::generate_credentials () {
+    TTCP_ID_CLIP=${TTCP_ID_CLIP:-"$(echo "${TTCP_ID}${TTCP_SALT1}" | __ttcp::hash)"}
+    TTCP_PASSWORD_CLIP=${TTCP_PASSWORD_CLIP:-"$(echo "${TTCP_PASSWORD}${TTCP_SALT1}" | __ttcp::hash)"}
+    TTCP_ID_TRANS=${TTCP_ID_TRANS:-"$(echo "${TTCP_ID}${TTCP_SALT2}" | __ttcp::hash)"}
+    TTCP_PASSWORD_TRANS=${TTCP_PASSWORD_TRANS:-"$(echo "${TTCP_PASSWORD}${TTCP_ID}${TTCP_SALT2}" | __ttcp::hash)"}
+}
+
 __ttcp::init () {
     # Stop immediately in case of any errors.
     # Because this function may make strange changes.
@@ -263,9 +270,17 @@ __ttcp::init () {
     # Force remove in advance, because the file may not have writable attribute.
     rm -f $_TTCP_CONFIG_FILE
     # Create blank file.
-    echo > $_TTCP_CONFIG_FILE
-    echo "TTCP_ID=$_given_id" > $_TTCP_CONFIG_FILE
-    echo "TTCP_PASSWORD=$_given_password1" >> $_TTCP_CONFIG_FILE
+    touch $_TTCP_CONFIG_FILE
+
+    TTCP_ID="$_given_id"
+    TTCP_PASSWORD="$_given_password1"
+    __ttcp::generate_credentials
+
+    echo "TTCP_ID_CLIP=$TTCP_ID_CLIP" > $_TTCP_CONFIG_FILE
+    echo "TTCP_PASSWORD_CLIP=$TTCP_PASSWORD_CLIP" >> $_TTCP_CONFIG_FILE
+    echo "TTCP_ID_TRANS=$TTCP_ID_TRANS" >> $_TTCP_CONFIG_FILE
+    echo "TTCP_PASSWORD_TRANS=$TTCP_PASSWORD_TRANS" >> $_TTCP_CONFIG_FILE
+
     # Prohibit users (except for root & current user) from seeing the file.
     chmod 400 $_TTCP_CONFIG_FILE
     echo  >&2
@@ -281,8 +296,10 @@ __ttcp::load_config () {
     local _file="${_TTCP_CONFIG_FILE:-$1}"
     __ttcp::check_config
     if [ $? -eq 0 ]; then
-        TTCP_ID="$(cat "$_file" | head -n 1 | sed 's/^TTCP_ID=//')"
-        TTCP_PASSWORD="$(cat "$_file" | tail -n 1 | sed 's/^TTCP_PASSWORD=//')"
+        TTCP_ID_CLIP="$(cat "$_file"        | perl -nle '$. ==  1 && print' | sed 's/^TTCP_ID_CLIP=//')"
+        TTCP_PASSWORD_CLIP="$(cat "$_file"  | perl -nle '$. ==  2 && print' | sed 's/^TTCP_PASSWORD_CLIP=//')"
+        TTCP_ID_TRANS="$(cat "$_file"       | perl -nle '$. ==  3 && print' | sed 's/^TTCP_ID_TRANS=//')"
+        TTCP_PASSWORD_TRANS="$(cat "$_file" | perl -nle '$. ==  4 && print' | sed 's/^TTCP_PASSWORD_TRANS=//')"
     else
         return 1
     fi
@@ -290,12 +307,15 @@ __ttcp::load_config () {
 
 # Config file format: ~/.ttcopy/config
 # -------------------------------------------------
-# Line1:TTCP_ID=<ID for ttcopy/ttpaste>
-# Line2:TTCP_PASSWORD=<Password for ttcopy/ttpaste>
+# Line1:TTCP_ID_CLIP=...
+# Line2:TTCP_PASSWORD_CLIP=...
+# Line3:TTCP_ID_TRANS=...
+# Line4:TTCP_PASSWORD_TRANS=...
 # <EOF>
 # -------------------------------------------------
 __ttcp::check_config () {
     local _file="${_TTCP_CONFIG_FILE:-$1}"
+    local _records="TTCP_ID_CLIP TTCP_PASSWORD_CLIP TTCP_ID_TRANS TTCP_PASSWORD_TRANS"
 
     # Check existence of the file.
     if [ ! -e "$_file" ]; then
@@ -303,31 +323,16 @@ __ttcp::check_config () {
         return 1
     fi
 
-    # Check ID follows format.
-    cat "$_file" | head -n 1 | grep -qE '^TTCP_ID=.+$'
-    if [ $? -ne 0 ]; then
-        return 1
-    fi
-
-    # Check Password follows format.
-    cat "$_file" | tail -n 1 | grep -qE '^TTCP_PASSWORD=.+$'
-    if [ $? -ne 0 ]; then
-        return 1
-    fi
-
-    # Check ID/password is empty or not.
-    local _line_num=$(cat "$_file" | \
-        # Remove prefix.
-        sed 's/^TTCP_ID=//' | \
-        sed 's/^TTCP_PASSWORD=//' | \
-        # If the number of field is 0, it's empty line (or the line contains space or tab only).
-        perl -anle 'scalar (@F) > 0 && print' | \
-        # Count number of lines
-        grep -c .)
-    if [ $_line_num -ne 2 ]; then
-        # Invalid format
-        return 1
-    fi
+    # Check format of the file.
+    local _counter=0;
+    while read _attr ; do
+        _counter=$(($_counter + 1))
+        cat "$_file" | head -n $_counter | tail -n 1 | grep -qE "^$_attr=.+$"
+        # If there is any parts which does not follow the format, return error.
+        if [ $? -ne 0 ]; then
+            return 1
+        fi
+    done < <(echo "$_records" | tr ' ' '\n')
 
     return 0
 }

--- a/lib/ttcp
+++ b/lib/ttcp
@@ -34,7 +34,7 @@ readonly _TTCP_ECONTTRANS=16
 # Failed to get the content url
 readonly _TTCP_ECONTURL=17
 
-# Credentials are initialized (btw, 1.2.4 sounds like "initi" in japanese).
+# Credentials are initialized
 readonly _TTCP_EINITCRED=124
 
 # Necessary commands are not found
@@ -276,7 +276,7 @@ __ttcp::init () {
     TTCP_PASSWORD="$_given_password1"
     __ttcp::generate_credentials
 
-    echo "TTCP_ID=$TTCP_ID" >> $_TTCP_CONFIG_FILE
+    echo "TTCP_ID=$TTCP_ID" > $_TTCP_CONFIG_FILE
     echo "TTCP_ID_CLIP=$TTCP_ID_CLIP" >> $_TTCP_CONFIG_FILE
     echo "TTCP_PASSWORD_CLIP=$TTCP_PASSWORD_CLIP" >> $_TTCP_CONFIG_FILE
     echo "TTCP_ID_TRANS=$TTCP_ID_TRANS" >> $_TTCP_CONFIG_FILE
@@ -295,16 +295,12 @@ __ttcp::init () {
 
 __ttcp::load_config () {
     local _file="${_TTCP_CONFIG_FILE:-$1}"
-    __ttcp::check_config
-    if [ $? -eq 0 ]; then
-        TTCP_ID="$(cat "$_file"             | head -n 1 | tail -n 1 | sed 's/^TTCP_ID=//')"
-        TTCP_ID_CLIP="$(cat "$_file"        | head -n 2 | tail -n 1 | sed 's/^TTCP_ID_CLIP=//')"
-        TTCP_PASSWORD_CLIP="$(cat "$_file"  | head -n 3 | tail -n 1 | sed 's/^TTCP_PASSWORD_CLIP=//')"
-        TTCP_ID_TRANS="$(cat "$_file"       | head -n 4 | tail -n 1 | sed 's/^TTCP_ID_TRANS=//')"
-        TTCP_PASSWORD_TRANS="$(cat "$_file" | head -n 5 | tail -n 1 | sed 's/^TTCP_PASSWORD_TRANS=//')"
-    else
-        return 1
-    fi
+    TTCP_ID="$(cat "$_file"             | head -n 1 | tail -n 1 | sed 's/^TTCP_ID=//')"
+    TTCP_ID_CLIP="$(cat "$_file"        | head -n 2 | tail -n 1 | sed 's/^TTCP_ID_CLIP=//')"
+    TTCP_PASSWORD_CLIP="$(cat "$_file"  | head -n 3 | tail -n 1 | sed 's/^TTCP_PASSWORD_CLIP=//')"
+    TTCP_ID_TRANS="$(cat "$_file"       | head -n 4 | tail -n 1 | sed 's/^TTCP_ID_TRANS=//')"
+    TTCP_PASSWORD_TRANS="$(cat "$_file" | head -n 5 | tail -n 1 | sed 's/^TTCP_PASSWORD_TRANS=//')"
+    return 0
 }
 
 # Config file format: ~/.ttcopy/config
@@ -340,7 +336,7 @@ __ttcp::check_config () {
     return 0
 }
 
-__ttcp::is_credential_valid() {
+__ttcp::is_credential_valid () {
     [ -z "$TTCP_ID" ] && \
         return $_TTCP_ENOCRED
     [ -z "$TTCP_PASSWORD" ] && \
@@ -348,7 +344,7 @@ __ttcp::is_credential_valid() {
     return 0
 }
 
-__ttcp::check_env () {
+__ttcp::is_dependency_installed () {
     while read cmd ; do
         type $cmd > /dev/null 2>&1
         if [ $? -ne 0 ]; then

--- a/lib/ttcp
+++ b/lib/ttcp
@@ -52,6 +52,17 @@ readonly _TTCP_EINTR=130
 # then added zsh support from http://stackoverflow.com/a/23259585 .
 _TTCP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%N}}")"; cd ..; pwd)"
 
+# NOTE: "/dev/tty" is bound to the input device of "current process".
+# Ref: http://tldp.org/HOWTO/Text-Terminal-HOWTO-7.html#ss7.3
+INPUT_DEVICE="/dev/tty"
+
+# Prevent ".ttcopy" being created under root / dir in any case.
+# This is quite rare case (but it can be happened).
+_USER_HOME="${HOME:-/etc}"
+_TTCP_USER_HOME="${_TTCP_USER_HOME:-$_USER_HOME}"
+_TTCP_CONFIG_DIR="$_TTCP_USER_HOME/.ttcopy"
+_TTCP_CONFIG_FILE="$_TTCP_CONFIG_DIR/config"
+
 # Dependent commands (non POSIX commands)
 _TTCP_DEPENDENCIES="${_TTCP_DEPENDENCIES:-yes openssl curl perl gzip}"
 
@@ -95,6 +106,7 @@ __ttcp::usage () {
     echo "  -V, --version                      Output the version number of $_cmd and exit."
     echo "  -i ID, --id=ID                     Specify ID to identify the data."
     echo "  -p PASSWORD, --password=PASSWORD   Specify password to encrypt/decrypt the data."
+    echo "  --init                             Set default ID and password."
 }
 
 __ttcp::opts () {
@@ -120,6 +132,10 @@ __ttcp::opts () {
             --password=*)
                 TTCP_PASSWORD="${1#--password=}"
                 shift
+                ;;
+            --init)
+                # exit in the function
+                __ttcp::init
                 ;;
 
             # Short options
@@ -198,6 +214,132 @@ __ttcp::spin () {
     _TTCP_SPIN_PID=$!
 }
 
+__ttcp::init () {
+    # Stop immediately in case of any errors.
+    # Because this function may make strange changes.
+    set -e
+
+    # Get a filename calling the function.
+    # http://stackoverflow.com/a/192319/
+    local _file="${0##*/}"
+    # Remove file's extention
+    local _cmd="${_file%.*}"
+
+    local _given_id=""
+    local _given_password1=""
+    local _given_password2=""
+
+    # If there is any standard input, discard it.
+    # If users try to use ttcopy with stdin for the first time.
+    if [ ! -t 0 ]; then
+        echo "The input is discarded because credentials are not set yet." >&2
+        echo "Please try again after setting ID/Password" >&2
+        echo >&2
+        cat /dev/stdin > /dev/null
+    fi
+
+    echo "Set default ID/Password." >&2
+    # Following messages are similar to ssh-keygen's one.
+
+    printf "Enter ID for ttcopy/ttpaste:" >&2
+    read _given_id < ${INPUT_DEVICE}
+
+    printf "Enter password for ttcopy/ttpaste:" >&2
+    read -s _given_password1 < ${INPUT_DEVICE}
+    echo >&2
+
+    printf "Enter same password again:" >&2
+    read -s _given_password2 < ${INPUT_DEVICE}
+    echo >&2
+
+    # Check passwords
+    if [[ "$_given_password1" !=  "$_given_password2" ]]; then
+        echo "Passwords do not match. Try again." >&2
+        exit $_TTCP_EUNMATCH
+    fi
+
+    # Try to create a directory to store credentials in any case.
+    mkdir -p "$_TTCP_CONFIG_DIR"
+    # Force remove in advance, because the file may not have writable attribute.
+    rm -f $_TTCP_CONFIG_FILE
+    # Create blank file.
+    echo > $_TTCP_CONFIG_FILE
+    echo "TTCP_ID=$_given_id" > $_TTCP_CONFIG_FILE
+    echo "TTCP_PASSWORD=$_given_password1" >> $_TTCP_CONFIG_FILE
+    # Prohibit users (except for root & current user) from seeing the file.
+    chmod 400 $_TTCP_CONFIG_FILE
+    echo  >&2
+    echo "Created credential file '$_TTCP_CONFIG_FILE'" >&2
+    echo "Execute '$_cmd --init' to show this screen again." >&2
+
+    # Unset errexit
+    set +e
+    exit $_TTCP_EINITCRED
+}
+
+__ttcp::load_config () {
+    local _file="${_TTCP_CONFIG_FILE:-$1}"
+    __ttcp::check_config
+    if [ $? -eq 0 ]; then
+        TTCP_ID="$(cat "$_file" | head -n 1 | sed 's/^TTCP_ID=//')"
+        TTCP_PASSWORD="$(cat "$_file" | tail -n 1 | sed 's/^TTCP_PASSWORD=//')"
+    else
+        return 1
+    fi
+}
+
+# Config file format: ~/.ttcopy/config
+# -------------------------------------------------
+# Line1:TTCP_ID=<ID for ttcopy/ttpaste>
+# Line2:TTCP_PASSWORD=<Password for ttcopy/ttpaste>
+# <EOF>
+# -------------------------------------------------
+__ttcp::check_config () {
+    local _file="${_TTCP_CONFIG_FILE:-$1}"
+
+    # Check existence of the file.
+    if [ ! -e "$_file" ]; then
+        # Does not exist.
+        return 1
+    fi
+
+    # Check ID follows format.
+    cat "$_file" | head -n 1 | grep -qE '^TTCP_ID=.+$'
+    if [ $? -ne 0 ]; then
+        return 1
+    fi
+
+    # Check Password follows format.
+    cat "$_file" | tail -n 1 | grep -qE '^TTCP_PASSWORD=.+$'
+    if [ $? -ne 0 ]; then
+        return 1
+    fi
+
+    # Check ID/password is empty or not.
+    local _line_num=$(cat "$_file" | \
+        # Remove prefix.
+        sed 's/^TTCP_ID=//' | \
+        sed 's/^TTCP_PASSWORD=//' | \
+        # If the number of field is 0, it's empty line (or the line contains space or tab only).
+        perl -anle 'scalar (@F) > 0 && print' | \
+        # Count number of lines
+        grep -c .)
+    if [ $_line_num -ne 2 ]; then
+        # Invalid format
+        return 1
+    fi
+
+    return 0
+}
+
+__ttcp::is_credential_valid() {
+    [ -z "$TTCP_ID" ] && \
+        return $_TTCP_ENOCRED
+    [ -z "$TTCP_PASSWORD" ] && \
+        return $_TTCP_ENOCRED
+    return 0
+}
+
 __ttcp::check_env () {
     while read cmd ; do
         type $cmd > /dev/null 2>&1
@@ -206,13 +348,6 @@ __ttcp::check_env () {
             exit $_TTCP_ENOCMD
         fi
     done < <(echo "$_TTCP_DEPENDENCIES" | tr ' ' '\n')
-
-    [ -z "$TTCP_ID" ] && \
-        echo "Set environment variable (TTCP_ID) or give the ID by -i option." >&2 && \
-        exit $_TTCP_ENOCRED
-    [ -z "$TTCP_PASSWORD" ] && \
-        echo "Set environment variable (TTCP_PASSWORD) or give the password by -p option." >&2 && \
-        exit $_TTCP_ENOCRED
     return 0
 }
 

--- a/lib/ttcp
+++ b/lib/ttcp
@@ -232,8 +232,8 @@ __ttcp::init () {
     # If there is any standard input, discard it.
     # If users try to use ttcopy with stdin for the first time.
     if [ ! -t 0 ]; then
-        echo "The input is discarded because credentials are not set yet." >&2
-        echo "Please try again after setting ID/Password" >&2
+        echo "Standard input is discarded because credentials are not set yet." >&2
+        echo "Please try again after setting ID/Password." >&2
         echo >&2
         cat /dev/stdin > /dev/null
     fi

--- a/lib/ttcp
+++ b/lib/ttcp
@@ -248,14 +248,14 @@ __ttcp::init () {
     echo "Set default ID/Password." >&2
     # Following messages are similar to ssh-keygen's one.
 
-    printf "Enter ID for ttcopy/ttpaste:" >&2
+    printf "Enter ID for ttcopy/ttpaste: " >&2
     read _given_id < ${INPUT_DEVICE}
 
-    printf "Enter password for ttcopy/ttpaste:" >&2
+    printf "Enter password for ttcopy/ttpaste: " >&2
     read -s _given_password1 < ${INPUT_DEVICE}
     echo >&2
 
-    printf "Enter same password again:" >&2
+    printf "Enter same password again: " >&2
     read -s _given_password2 < ${INPUT_DEVICE}
     echo >&2
 

--- a/lib/ttcp
+++ b/lib/ttcp
@@ -283,7 +283,7 @@ __ttcp::init () {
     echo "TTCP_PASSWORD_TRANS=$TTCP_PASSWORD_TRANS" >> $_TTCP_CONFIG_FILE
 
     # Prohibit users (except for root & current user) from seeing the file.
-    chmod 400 $_TTCP_CONFIG_FILE
+    chmod 600 $_TTCP_CONFIG_FILE
     echo  >&2
     echo "Created credential file '$_TTCP_CONFIG_FILE'" >&2
     echo "Execute '$_cmd --init' to show this screen again." >&2

--- a/lib/ttcp
+++ b/lib/ttcp
@@ -60,7 +60,7 @@ INPUT_DEVICE="/dev/tty"
 # This is quite rare case (but it can be happened).
 _USER_HOME="${HOME:-/etc}"
 _TTCP_USER_HOME="${_TTCP_USER_HOME:-$_USER_HOME}"
-_TTCP_CONFIG_DIR="$_TTCP_USER_HOME/.ttcopy"
+_TTCP_CONFIG_DIR="$_TTCP_USER_HOME/.config/ttcopy"
 _TTCP_CONFIG_FILE="$_TTCP_CONFIG_DIR/config"
 
 # Dependent commands (non POSIX commands)

--- a/lib/ttcp
+++ b/lib/ttcp
@@ -19,11 +19,23 @@ readonly _TTCP_EINVAL=4
 # Nothing has been copied yet
 readonly _TTCP_ENOCONTENT=5
 
+# Passwords do not match
+readonly _TTCP_EUNMATCH=6
+
 # Failed to encode something.
 readonly _TTCP_EENCODE=7
 
 # Failed to decode something.
 readonly _TTCP_EDECODE=8
+
+# Failed to upload/download the content
+readonly _TTCP_ECONTTRANS=16
+
+# Failed to get the content url
+readonly _TTCP_ECONTURL=17
+
+# Credentials are initialized (btw, 1.2.4 sounds like "initi" in japanese).
+readonly _TTCP_EINITCRED=124
 
 # Necessary commands are not found
 readonly _TTCP_ENOCMD=127
@@ -31,11 +43,6 @@ readonly _TTCP_ENOCMD=127
 # Terminated by Ctl-C
 readonly _TTCP_EINTR=130
 
-# Failed to upload/download the content
-readonly _TTCP_ECONTTRANS=16
-
-# Failed to get the content url
-readonly _TTCP_ECONTURL=17
 
 # ===============
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -269,9 +269,9 @@ test_init_multiple () {
 test_init_and_try () {
     local _myid="$(genId myid)"
     local _mypassword="$(randomString)"
+
     TTCP_ID=""
     TTCP_PASSWORD=""
-
     _TTCP_USER_HOME="${SHUNIT_TMPDIR}/try"
 
     # First time
@@ -280,7 +280,7 @@ test_init_and_try () {
     seq 200 210 | ttcopy
 
     assertEquals "$(seq 200 210)" "$(ttpaste)"
-    assertEquals "$(seq 200 210)" "$(ttpaste -i $_myid -p $_mypassword)"
+    assertEquals "$(seq 200 210)" "$(ttpaste -i "$_myid" -p "$_mypassword")"
 
     rm -rf "$_TTCP_USER_HOME"
 }
@@ -299,6 +299,8 @@ test_invalid_config_format () {
 
     # Delete one of the line
     cat "$_TTCP_USER_HOME/.ttcopy/config" | grep -Ev '^TTCP_ID_CLIP=.*$' > "$_TTCP_USER_HOME/.ttcopy/config_tmp"
+    # Force delete. Because permission is read-only.
+    rm -f "$_TTCP_USER_HOME/.ttcopy/config"
     mv "$_TTCP_USER_HOME/.ttcopy/config_tmp" "$_TTCP_USER_HOME/.ttcopy/config"
 
     # Initial screen will be displayd at the second time also.
@@ -336,7 +338,7 @@ test_check_credential_priority () {
 
     # If either environment variable is empty, use config file.
     TTCP_ID=""
-    TTCP_PASSWORD=""
+    TTCP_PASSWORD="test"
     seq 100 300 | ttcopy
     assertEquals "$(seq 100 300)" "$(ttpaste -i "$_id_conf" -p "$_password_conf")"
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -282,6 +282,26 @@ test_init_and_try () {
     assertEquals "$(seq 200 210)" "$(ttpaste -i $_myid -p $_mypassword)"
 }
 
+test_invalid_config_format () {
+    local _myid="$(genId myid)"
+    local _mypassword="$(randomString)"
+    TTCP_ID=""
+    TTCP_PASSWORD=""
+
+    _TTCP_USER_HOME="${SHUNIT_TMPDIR}/invalid"
+
+    # First time
+    simulateInitializer "$_myid" "$_mypassword" "$_mypassword" 'ttcopy --init'
+    assertEquals 124 $?
+
+    # Delete one of the line
+    sed -i 's/TTCP_ID_CLIP=.*//g' $_TTCP_USER_HOME/.ttcopy/config
+
+    # Initial screen will be displayd at the second time also.
+    simulateInitializer "$_myid" "$_mypassword" "$_mypassword" 'seq 10 | ttcopy'
+    assertEquals 124 $?
+}
+
 test_proxy () {
     # If there is not docker on this machine, this test will be skipped.
     if (type docker); then

--- a/test/test.sh
+++ b/test/test.sh
@@ -33,7 +33,7 @@ setUp () {
     # TMPDIR does not work on particular environments.
     export _TTCP_USER_HOME="${SHUNIT_TMPDIR}"
     # Delete in advance
-    rm -rf "$_TTCP_USER_HOME/.ttcopy"
+    rm -rf "$_TTCP_USER_HOME/.config/ttcopy"
     echo ">>>>>>>>>>" >&2
 }
 
@@ -298,10 +298,9 @@ test_invalid_config_format () {
     assertEquals 124 $?
 
     # Delete one of the line
-    cat "$_TTCP_USER_HOME/.ttcopy/config" | grep -Ev '^TTCP_ID_CLIP=.*$' > "$_TTCP_USER_HOME/.ttcopy/config_tmp"
-    # Force delete. Because permission is read-only.
-    rm -f "$_TTCP_USER_HOME/.ttcopy/config"
-    mv "$_TTCP_USER_HOME/.ttcopy/config_tmp" "$_TTCP_USER_HOME/.ttcopy/config"
+    cat "$_TTCP_USER_HOME/.config/ttcopy/config" | grep -Ev '^TTCP_ID_CLIP=.*$' > "$_TTCP_USER_HOME/.config/ttcopy/config_tmp"
+    rm -f "$_TTCP_USER_HOME/.config/ttcopy/config"
+    mv "$_TTCP_USER_HOME/.config/ttcopy/config_tmp" "$_TTCP_USER_HOME/.config/ttcopy/config"
 
     # Initial screen will be displayd at the second time also.
     simulateInitializer "$_myid" "$_mypassword" "$_mypassword" 'seq 10 | ttcopy'


### PR DESCRIPTION
# Following changes are going to be made for the issue #5.

## 1. Initial screen for new user.

```sh
$ ttcopy #<= Executed for the first time.
Set default ID/Password.
Enter ID for ttcopy/ttpaste:myid001
Enter password for ttcopy/ttpaste:
Enter same password again:

Created credential file '/Users/user/.ttcopy/config'
Execute 'ttcopy --init' to show this screen again.
```

New option `--init` is newly prepared to let users show this screen on themselves.

## 2. Store following credential information to ~/.ttcopy/config file.

**~/.ttcopy/config** example

```sh
TTCP_ID=myid001
TTCP_ID_CLIP=5097060b2c82e85e2d56facfac0c42b97201bd7367d1951afb03e327f419bbb1
TTCP_PASSWORD_CLIP=a8d773f50e67bbd77d2df4162a51f4c3dc66292817e25e8642d558d36e322090
TTCP_ID_TRANS=09f377b1a82b024f7c00bff863bad8889e87e472477f478b2fbbd2f4e1ae4a63
TTCP_PASSWORD_TRANS=858479456e3df6a1ebb7eeef2d00a2c8ded57648706806bfdc7dfb2aded7c762
```

There are two improvements.

* `config` file will be saved with read only permission `-r--------`.
  + All users except for root and current user cannot see the credentials.

* Raw `TTCP_PASSWORD` is NOT stored to anywhere.
  + To prevent social engineering. Because same password is tend to be used on the other web service.

## 3. Define new error codes.

| Description                                         | Exit status   | Note                                                                 |
| -------------                                       | ------------- | -----                                                                |
| Given passwords on the initial screen do not match. | 6             |                                                                      |
| Credentials are initialized on the initial screen.  | 124           | Actually it is not error. "124" sounds like "initi" in japanese btw. |


## 4. etc

* Update README.md and small refactoring.
* In this version, there are three ways to set the credentials. As I mentioned in #5, there is the priority.

* * *

I suppose that this new version will be `v2.2.0`.
It seems big changes, but it still keeps backwards compatibility.
