### PR TITLE
Use "-" instead of process substitution in curl

### DIFF
--- a/bin/ttcopy
+++ b/bin/ttcopy
@@ -27,7 +27,7 @@ _HTTP_CLIENT="$(__ttcp::http_client)"
 # TTCP_ID_CLIP, TTCP_PASSWORD_CLIP, TTCP_ID_TRANS, TTCP_PASSWORD_TRANS
 __ttcp::generate_credentials
 
-TRANS_URL=$(${_HTTP_CLIENT} -so- --fail --upload-file <(cat | __ttcp::encode "${TTCP_PASSWORD_TRANS}") $TTCP_TRANSFER_SH/$TTCP_ID_TRANS );
+TRANS_URL=$(cat | __ttcp::encode "${TTCP_PASSWORD_TRANS}" | ${_HTTP_CLIENT} -so- --fail --upload-file - $TTCP_TRANSFER_SH/$TTCP_ID_TRANS );
 
 if [ $? -ne 0 ]; then
     __ttcp::unspin


### PR DESCRIPTION
Fix #42 
`ttcopy` does not work on the specific condition.
As we discussed in #42, it did not work on CentOS 6.6 on docker.

Unfortunately, Linux on Travic CI is Ubuntu 12.04.
Therefore, I put the evidence instead.

CentOS 6.6 on docker.
```
[root@f5b3c7895dbe ttcopy]# cat /etc/redhat-release
CentOS release 6.6 (Final)
[root@f5b3c7895dbe ~]# ttcopy --version
2.2.0
[root@f5b3c7895dbe ~]# seq 10 | ttcopy -i hoge -p fuga
Copied!
[root@f5b3c7895dbe ~]# ttpaste -i hoge -p fuga
bad decrypt
140188259354440:error:0606506D:digital envelope routines:EVP_DecryptFinal_ex:wrong final block length:evp_enc.c:589:

gzip: stdin: unexpected end of file
Failed to decode data.
Please check ID/Password and Salt values.
[root@f5b3c7895dbe ~]# cd ~/ttcopy/
[root@f5b3c7895dbe ttcopy]# git fetch
[root@f5b3c7895dbe ttcopy]# git checkout bugfix/curl_proc_substituion
Branch bugfix/curl_proc_substituion set up to track remote branch bugfix/curl_proc_substituion from origin.
Switched to a new branch 'bugfix/curl_proc_substituion'
[root@f5b3c7895dbe ttcopy]# seq 10 | ttcopy -i hoge -p fuga
Copied!
[root@f5b3c7895dbe ttcopy]# ttpaste -i hoge -p fuga
1
2
3
4
5
6
7
8
9
10
```

* * *
I think, next version will be `v2.2.1`.